### PR TITLE
fix(toString): IE11 fix (TypeError: Invalid calling object)

### DIFF
--- a/src/utils/is-function.ts
+++ b/src/utils/is-function.ts
@@ -1,7 +1,7 @@
 export default function isFunction(value: unknown): value is Function {
   return !!value
     && (
-      toString.call(value) === '[object Function]'
+      Object.prototype.toString.call(value) === '[object Function]'
       || typeof value === 'function'
     )
 }

--- a/src/utils/is-promise.ts
+++ b/src/utils/is-promise.ts
@@ -1,7 +1,7 @@
 export default function isPromise<T = unknown>(value: unknown): value is PromiseLike<T> {
   return !!value
     && (
-      toString.call(value) === '[object Promise]'
+      Object.prototype.toString.call(value) === '[object Promise]'
       || typeof value === 'function'
     )
     && typeof (value as PromiseLike<unknown>).then === 'function'


### PR DESCRIPTION
in IE 11 
fails: toString.call(function(){}) 
works: Object.prototype.toString.call(function(){})