### PR TITLE
Remove debug log from `isAsyncStorage`

### DIFF
--- a/src/utils/is-async-storage.ts
+++ b/src/utils/is-async-storage.ts
@@ -20,16 +20,6 @@ export default function isAsyncStorage(storage: unknown): storage is AsyncStorag
         || isFunction((storage as any).remove) && isPromise((storage as any).remove(''))
         || isAsyncFunction((storage as any).remove)
 
-    console.log('isAsyncStorage', {
-        storage,
-        hasGet,
-        hasSet,
-        hasRemove,
-        hasGetPromise,
-        hasSetPromise,
-        hasRemovePromise,
-    })
-
     return Boolean(storage)
         && hasGet
         && hasSet


### PR DESCRIPTION
This would appear in an app's logs every time a store is initialized.