### PR TITLE
fix: remove debug console.log from isAsyncStorage function

### DIFF
--- a/src/utils/is-async-storage.ts
+++ b/src/utils/is-async-storage.ts
@@ -20,15 +20,6 @@ export default function isAsyncStorage(storage: unknown): storage is AsyncStorag
         || isFunction((storage as any).remove) && isPromise((storage as any).remove(''))
         || isAsyncFunction((storage as any).remove)
 
-    console.log('isAsyncStorage', {
-        storage,
-        hasGet,
-        hasSet,
-        hasRemove,
-        hasGetPromise,
-        hasSetPromise,
-        hasRemovePromise,
-    })
 
     return Boolean(storage)
         && hasGet


### PR DESCRIPTION
This PR removes the debug console.log statement from the isAsyncStorage function that was polluting application logs. The console.log was used for debugging purposes and should not be present in production code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary debug logging from storage utility for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->