### PR TITLE
docs: add agent rules for Claude and Codex

### DIFF
--- a/.agents/rules/code-design-best-practices.md
+++ b/.agents/rules/code-design-best-practices.md
@@ -1,0 +1,65 @@
+---
+description: DRY, SOLID, clean code and clean architecture rules, with the violations this codebase already contains
+trigger: always
+tags:
+  - design
+  - architecture
+  - solid
+  - dry
+---
+
+## Code Design Best Practices
+
+These are requirements, not aspirations. A change that violates one of them is not finished, however
+well it works.
+
+### DRY
+
+**Never duplicate logic.** Two copies drift apart, and the second one is the one nobody updates. When
+the same behaviour is needed twice, extract it — and when you find yourself copying a file to adapt
+it, that is the moment to factor out the shared part instead.
+
+This codebase already carries the violation: `src/storages/chrome-storage.ts` and
+`src/storages/browser-storage.ts` are near-identical copies — same listener registry, same
+`fireStorageEvent`, same `createOnChanged`, differing only in the extension API they call. Adding a
+third backend by copying a second time makes it worse.
+
+DRY is about knowledge, not characters. Two pieces of code that look alike but answer to different
+reasons for change should stay apart; merging them couples things that must move independently.
+
+### SOLID
+
+- **Single responsibility.** A module has one reason to change. A file that both talks to a storage
+  backend and decides React state has two.
+- **Open/closed.** New behaviour arrives as a new adapter implementing `Storage` or `AsyncStorage`,
+  not as another branch inside the hook. If supporting a backend requires editing the core, the
+  abstraction is wrong.
+- **Liskov substitution.** Every adapter must be usable wherever the interface is expected, with no
+  surprises. An adapter that silently drops values, or whose `get` returns something the contract does
+  not allow, breaks callers that were written against the interface.
+- **Interface segregation.** Keep `Storage` and `AsyncStorage` minimal. Do not add a method to the
+  public interface because one adapter finds it convenient — every implementer then has to provide it.
+- **Dependency inversion.** The hook depends on the `Storage` abstraction, never on a concrete
+  backend. This is the load-bearing design decision of the library: `createPersistedState` accepts any
+  adapter, which is why consumers can supply their own. Never import `localStorage` or `chrome.storage`
+  into core logic.
+
+### Clean architecture
+
+Dependencies point inward. The core — the hooks and their helpers — knows nothing about which backend
+it serves; concrete knowledge lives at the edges, in `src/storages/`. Anything specific to a backend
+(chrome storing arbitrary JSON, web storage holding only strings) is normalized **in the adapter**, so
+the core sees one uniform contract.
+
+Never leak a backend's quirks inward, and never widen a core type to accommodate one adapter.
+
+### Clean code
+
+- Functions do one thing and are small enough to read at once.
+- No surprises: a function named as a query does not mutate anything. **A predicate must have no side
+  effects.** `isAsyncStorage` currently violates this — it detects async support by *calling*
+  `get('')`, `set({})` and `remove('')` on the storage it inspects, so merely asking a question writes
+  to the user's storage.
+- Prefer clear names over comments; when a comment is needed, it explains why.
+- No flag parameters that make a function do two different things.
+- Fail loudly and early rather than continuing with a broken value.

--- a/.agents/rules/code-quality.md
+++ b/.agents/rules/code-quality.md
@@ -1,0 +1,30 @@
+---
+description: Code quality rules - no dead code, no swallowed errors, no speculative code
+trigger: always
+tags:
+  - code
+  - quality
+  - rules
+---
+
+## Code Quality
+
+1. **Delete dead code.** No commented-out blocks kept "just in case", no unreachable branches. Version
+   control already remembers them, and a reader cannot tell a safety net from an oversight.
+
+2. **One implementation per behaviour.** When a new path replaces an old one, the old one goes in the
+   same change. Two paths mean two sets of bugs and no source of truth.
+
+3. **Never swallow errors.** Do not catch an exception only to ignore it — a silent catch turns a bug
+   into a mystery days later. Where a failure is genuinely expected, such as a stored value that will
+   not parse, handle it deliberately and leave the reason in a comment.
+
+4. **Finish migrations.** Moving from A to B means B works and A is gone, in one change. A half
+   migration forces every future reader to hold both models in their head.
+
+5. **No speculative code.** No parameter, option or abstraction added because it "might be needed".
+   Add it when a caller actually needs it.
+
+6. **Mind what a change costs at runtime.** This hook runs on every render of every consuming
+   component. Synchronous storage reads, `JSON.parse` calls and subscription churn sitting in a render
+   path are expensive here in a way they would not be in a one-off script.

--- a/.agents/rules/core-principles.md
+++ b/.agents/rules/core-principles.md
@@ -1,0 +1,43 @@
+---
+description: How to work in this repository - research first, no patches, agree before implementing
+trigger: always
+tags:
+  - principles
+  - guidelines
+  - workflow
+---
+
+## Core Principles
+
+1. **Find the root cause; never work around it.** A change that hides a symptom leaves the defect in
+   place and buys nothing.
+
+2. **Research before changing.** When something breaks, an upgrade fails, or an API is unfamiliar,
+   read the official documentation, the changelog and the upstream issue tracker *first*, then decide.
+   Do not fix by trial and error — installing something to see what breaks produces confident wrong
+   conclusions.
+
+3. **No patches.** Dependency `overrides`, `--legacy-peer-deps`, and flags that silence a check are
+   forbidden. They outlive the problem they hide and quietly become permanent. If an upgrade does not
+   resolve cleanly, the correct outcome is to stay on the current version and say why, citing the
+   source.
+
+4. **Agree before implementing.** Decisions that shape the project — replacing a tool, changing the
+   build, restructuring files, adding or dropping a dependency — are proposed and agreed first.
+   Announcing a decision that is already implemented is not agreement.
+
+5. **Never commit or push without explicit permission.** Committing, pushing, opening a pull request
+   and releasing each need their own instruction, every time. Permission for one is never permission
+   for the next.
+
+6. **Never destroy work that is not yours.** `git checkout --`, `git restore`, `git reset --hard`,
+   `git clean`, `git stash drop` and force pushes are off limits unless the specific file or command
+   is named. Uncommitted work cannot be recovered.
+
+7. **Follow what the project already does.** Match existing structure, naming and error handling
+   before introducing a new pattern, and prefer extending something that exists over adding a second
+   way to do the same thing.
+
+8. **Be honest about what was actually verified.** Report the command that ran and what it printed.
+   Never claim a gate passed, a bug is fixed, or a fact is confirmed without having seen it. When
+   something is incomplete or uncertain, say so plainly instead of rounding up.

--- a/.agents/rules/git-workflow-guidelines.md
+++ b/.agents/rules/git-workflow-guidelines.md
@@ -1,0 +1,45 @@
+---
+description: Conventional commits drive the released version; each git action needs its own permission
+trigger: always
+tags:
+  - git
+  - commits
+  - releases
+---
+
+## Git Workflow
+
+### Commits
+
+Commit messages follow Conventional Commits, and here that is load-bearing rather than cosmetic:
+`@release-it/conventional-changelog` derives the released version and the changelog directly from
+them. A wrong type ships a wrong version to everyone who installs the package.
+
+```
+<type>: <summary in present tense, not capitalised, no trailing period>
+```
+
+| Type | Effect on the release |
+| --- | --- |
+| `fix:` | patch |
+| `feat:` | minor |
+| `BREAKING CHANGE:` in the body | major |
+| `chore:`, `docs:`, `test:`, `refactor:`, `build:`, `ci:` | no release |
+
+Use the body to explain **why** the change was made and what it costs. The diff already shows what
+changed; it cannot show what you rejected and why.
+
+### Branches
+
+Work on a branch, never directly on `main`. Names are lowercase and descriptive of the change —
+`fix-null-round-trip`, not `fix-1` or `patch-2`.
+
+### Permission is per action
+
+Committing, pushing, opening a pull request and releasing are four separate actions, and each one
+needs its own explicit instruction, every time. Being told to commit is not permission to push. Being
+told to push is not permission to open a pull request. Being asked to prepare a release is not
+permission to publish one.
+
+When in doubt, stop and ask. An unwanted local commit costs a moment; an unwanted push or publish is
+visible to everyone and cannot be quietly undone.

--- a/.agents/rules/javascript-typescript-guidelines.md
+++ b/.agents/rules/javascript-typescript-guidelines.md
@@ -1,0 +1,41 @@
+---
+description: TypeScript types, naming and comment conventions for source, tests and demo
+trigger: always
+tags:
+  - typescript
+  - naming
+  - style
+---
+
+## JavaScript and TypeScript Guidelines
+
+### Types
+
+- Keep the public surface explicit. Exported functions state their parameter and return types instead
+  of relying on inference, so a change to the contract shows up in the diff.
+- Avoid `any`. Prefer `unknown` plus a narrowing check at the boundary where untyped data enters —
+  values coming out of a storage backend are the usual case, and they genuinely are unknown until
+  checked.
+- Never widen a public type to make an internal problem go away. Narrow at the adapter instead: the
+  library writes serialized strings, even where a backend's own types allow arbitrary JSON.
+
+### Naming
+
+- Name by role, not by type. No Hungarian notation, no type encoded in the name.
+- `camelCase` for variables, functions, methods and properties; `PascalCase` for types, interfaces and
+  components; `CONSTANT_CASE` only for module-level constants.
+- Booleans read as predicates: `is`, `has`, `should`, `can`.
+- **A `use` prefix means the function is a real React hook** — one that calls other hooks. Never put it
+  on a plain helper or factory. It misleads readers and lint rules alike, and this repository has
+  already carried a `use`-prefixed factory called from inside an effect while the actual hook was
+  anonymous.
+- File names are kebab-case and match what they export.
+
+### Comments
+
+- Explain **why**, never restate **what** the code already shows. If code needs a comment to be
+  understood, fix the naming or the structure instead.
+- Worth recording: an invariant, a trade-off, the reason a value is narrowed, the bug a guard prevents.
+- Forbidden: commented-out code, changelog or authorship notes, banner separators, and comments that
+  no longer match the code beside them.
+- Document exports with TSDoc, without repeating what the type signature already says.

--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -1,0 +1,44 @@
+---
+description: What this library is, its public API surface, commands, and which upgrades are blocked
+trigger: always
+tags:
+  - overview
+  - library
+  - versioning
+---
+
+## Project Overview
+
+`@plq/use-persisted-state` is a published npm library: a React hook that keeps state in a storage
+backend. Everything under `src/` is public API that other projects depend on, so a careless change to
+a signature or to observable behaviour breaks strangers' builds.
+
+- **Runtime dependencies: `@plq/is` only.** Keep it that way — this package is chosen for being small.
+- **Peer:** React >= 16.8 (hooks), supports 18 and 19.
+- **Entry point** is `src/index.ts`. Storage adapters live in `src/storages/`, internals in
+  `src/utils/`, public types in `src/@types/`.
+- **`lib/` is build output** produced by `tsc`. Never edit it by hand.
+- **`demo/`** is a Vite example app and is not published.
+
+### Commands
+
+| Task | Command |
+| --- | --- |
+| Install | `npm ci` |
+| Test | `npm test` |
+| Lint | `npm run lint` |
+| Build | `npm run build` |
+| Demo dev server | `npm run demo` |
+
+### Versioning
+
+Public API changes follow semver. A behaviour change that users can observe — what the hook returns,
+when it re-renders, what lands in storage — is breaking even when the type signature is untouched.
+
+### Upgrades known to be blocked
+
+- **TypeScript must not go to 7.** TypeScript 7 ships the Go compiler and removes the JS compiler API
+  that ts-jest is built on, so the whole test suite stops running. Blocked until ts-jest supports it.
+
+Keep the reason written next to any pin. A pin without a stated reason gets "helpfully" removed by
+whoever touches dependencies next.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,0 +1,51 @@
+---
+description: Testing rules - prove a test can fail, never enshrine a bug as the contract
+trigger: always
+tags:
+  - testing
+  - jest
+  - quality
+---
+
+## Testing
+
+Jest with ts-jest and React Testing Library in a jsdom environment. Storage is mocked with
+`jest-localstorage-mock` and `jest-webextension-mock`.
+
+### A test must be proven able to fail
+
+Before a test counts as coverage, watch it go **red** against the broken or unfixed code, then green
+after the fix. A test that passes both before and after the change tests nothing, and it is worse than
+no test, because it manufactures confidence.
+
+For a bug fix this is not optional: write the test, run it against the unfixed code, keep the failure
+output, then fix. For a behaviour-preserving refactor the bar is different — there is no failure to
+produce, so the standard is that the entire existing suite is green before and after, with no test
+temporarily broken for ceremony.
+
+### Never enshrine a bug as the contract
+
+This repository already contains tests that assert the defect. Cases state that `null` "is not saved,
+so the initial value stays" — while the real behaviour is that `null` **is** written to storage and
+then fails to read back. The test locked the bug in and made it invisible to everyone after.
+
+When behaviour looks wrong, fix the behaviour and the test. Never write an assertion whose only
+justification is "this is what the code currently does".
+
+### Test the real target
+
+A suite that runs against the wrong branch, the wrong environment or a stale build proves nothing,
+however green it is. SSR is the trap here: a test running under jsdom has `window` defined, so it can
+never prove that importing a module works without a DOM. That has to run in a Node environment, or the
+test is green by construction.
+
+### Practice
+
+- Drive hooks with `renderHook`; wrap state updates and async work in `act`.
+- Assert observable behaviour, not internal state.
+- Clean up between cases. Some adapters keep module-level registries, so state leaks across tests and
+  one case can silently pass because another ran first.
+- Cover both the sync and the async storage paths — they are separate implementations with separate
+  failure modes.
+- Verify that listeners are removed and effects cleaned up. Leaked subscriptions are a real failure
+  mode for this library, not a hypothetical one.

--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../.agents/rules


### PR DESCRIPTION
Adds project rules for AI agents. The repository had none beyond Copilot-specific
instructions, so every agent worked from guesswork.

## Layout

```
.agents/rules/                    single copy, 7 rules
.claude/rules -> ../.agents/rules symlink
```

One copy rather than two: keeping parallel directories in sync by hand would
duplicate exactly what the rules forbid. The internal rule-sync tooling used in
other repositories is not an option here — it lives in a private registry and
would break `npm ci` for an open-source project and its contributors.

## Why no path scoping

Every rule is unconditional. Claude Code silently fails to load a rule whose
`paths` front matter is a YAML list — the format the `.agents` proposal uses —
so path-scoped rules would appear configured while never applying
([anthropics/claude-code#17204](https://github.com/anthropics/claude-code/issues/17204),
closed as not planned). At 648 lines of source across 15 files, scoping buys
nothing anyway.

## The rules

| Rule | Covers |
| --- | --- |
| `project-overview` | library surface, semver, commands, why TypeScript cannot go to 7 |
| `core-principles` | root cause over workaround, research before changing, no patches, agree before implementing, permission per git action |
| `code-design-best-practices` | DRY, SOLID, clean architecture, clean code |
| `code-quality` | dead code, swallowed errors, speculative code, cost in a render path |
| `javascript-typescript-guidelines` | types, naming, `use` prefix reserved for real hooks, comments explaining why |
| `testing` | prove a test can fail, never enshrine a bug as the contract, SSR cannot be verified under jsdom |
| `git-workflow-guidelines` | conventional commits drive the released version |

## Adapted, not copied

Content is written for this project. Internal conventions from other
repositories — ticket-prefixed commits, internal services — are left out, and
the design rules cite violations that exist here:

- `chrome-storage.ts` and `browser-storage.ts` are near-identical copies, sharing
  listener registry, `fireStorageEvent` and `createOnChanged`.
- `isAsyncStorage` is a predicate with side effects: it detects async support by
  calling `get('')`, `set({})` and `remove('')` on the storage it inspects, so
  asking the question writes to the user's storage.
- Tests assert that `null` "is not saved", when `null` is in fact written to
  storage and then fails to read back — the test locked the bug in.