### PR TITLE
fix(chrome-storage): repair the build and deduplicate the extension adapters

### DIFF
--- a/__tests__/utils/extension-storage.test.ts
+++ b/__tests__/utils/extension-storage.test.ts
@@ -1,0 +1,57 @@
+import { createListenerRegistry, toStorageChanges, toStoredItems } from '../../src/utils/extension-storage'
+
+describe('extension-storage', function () {
+  describe('listener registry', function () {
+    test('dispatches to listeners of the area that changed', function () {
+      const registry = createListenerRegistry()
+      const listener = jest.fn()
+
+      registry.createOnChanged('local').addListener(listener)
+      registry.fire({ key: { oldValue: null, newValue: 'value' } }, 'local')
+
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not leak a change between areas', function () {
+      const registry = createListenerRegistry()
+      const listener = jest.fn()
+
+      registry.createOnChanged('local').addListener(listener)
+      registry.fire({ key: { oldValue: null, newValue: 'value' } }, 'sync')
+
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    // Both browsers also report `session` changes, an area this library does not
+    // track. Dispatching one used to read an undefined listener set and throw.
+    test('ignores changes from an area it does not track', function () {
+      const registry = createListenerRegistry()
+      const listener = jest.fn()
+
+      registry.createOnChanged('local').addListener(listener)
+
+      expect(() => {
+        registry.fire({ key: { oldValue: null, newValue: 'value' } }, 'session' as never)
+      }).not.toThrow()
+      expect(listener).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('value narrowing', function () {
+    test('keeps strings and drops everything else', function () {
+      expect(toStoredItems({ a: 'kept', b: 42, c: { nested: true }, d: null })).toEqual({ a: 'kept' })
+    })
+
+    test('reports non-string change values as absent', function () {
+      expect(toStorageChanges({ key: { oldValue: 42, newValue: 'text' } })).toEqual({
+        key: { oldValue: null, newValue: 'text' },
+      })
+    })
+
+    test('preserves undefined, which means the key was absent', function () {
+      expect(toStorageChanges({ key: { newValue: 'text' } })).toEqual({
+        key: { oldValue: undefined, newValue: 'text' },
+      })
+    })
+  })
+})

--- a/src/storages/browser-storage.ts
+++ b/src/storages/browser-storage.ts
@@ -1,42 +1,18 @@
-import { AsyncStorage, StorageChange, StorageChangeEvent, StorageChangeListener } from '../@types/storage'
+import { AsyncStorage } from '../@types/storage'
+import { Area, createListenerRegistry, toStorageChanges, toStoredItems } from '../utils/extension-storage'
 
-const listeners = {
-  local: new Set<StorageChangeListener>(),
-  sync: new Set<StorageChangeListener>(),
-  managed: new Set<StorageChangeListener>(),
-}
-
-type Area = keyof typeof listeners
-
-function fireStorageEvent(changes: { [key: string]: StorageChange }, area: Area) {
-  listeners[area].forEach(listener => {
-    listener(changes)
-  })
-}
+const registry = createListenerRegistry()
 
 browser.storage.onChanged.addListener((changes, area) => {
-  fireStorageEvent(changes, area as Area)
+  registry.fire(toStorageChanges(changes), area as Area)
 })
 
-function createOnChanged(area: Area): StorageChangeEvent {
-  return {
-    addListener(listener) {
-      listeners[area].add(listener)
-    },
-    removeListener(listener) {
-      listeners[area].delete(listener)
-    },
-    hasListener(listener) {
-      return listeners[area].has(listener)
-    },
-  }
-}
-
+// browser.storage is promise-based, unlike its callback-based chrome counterpart.
 const createStorage = (storage: browser.storage.StorageArea, area: Area): AsyncStorage => ({
-  get: storage.get,
+  get: async keys => toStoredItems(await storage.get(keys)),
   set: storage.set,
   remove: storage.remove,
-  onChanged: createOnChanged(area),
+  onChanged: registry.createOnChanged(area),
 })
 
 const local = createStorage(browser.storage.local, 'local')

--- a/src/storages/browser-storage.ts
+++ b/src/storages/browser-storage.ts
@@ -4,7 +4,7 @@ import { Area, createListenerRegistry, toStorageChanges, toStoredItems } from '.
 const registry = createListenerRegistry()
 
 browser.storage.onChanged.addListener((changes, area) => {
-  registry.fire(toStorageChanges(changes), area as Area)
+  registry.fire(toStorageChanges(changes), area)
 })
 
 // browser.storage is promise-based, unlike its callback-based chrome counterpart.

--- a/src/storages/chrome-storage.ts
+++ b/src/storages/chrome-storage.ts
@@ -8,6 +8,41 @@ const listeners = {
 
 type Area = keyof typeof listeners
 
+// chrome.storage holds arbitrary JSON, while this library only ever writes
+// serialized strings. Anything else under a key belongs to other code: it is
+// reported as absent rather than passed on as if this library had written it,
+// which is what the previous code did until it failed to parse.
+function toStoredValue(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined
+
+  return typeof value === 'string' ? value : null
+}
+
+function toStorageChanges(
+  changes: { [key: string]: chrome.storage.StorageChange },
+): { [key: string]: StorageChange } {
+  const result: { [key: string]: StorageChange } = {}
+
+  Object.entries(changes).forEach(([key, change]) => {
+    result[key] = {
+      oldValue: toStoredValue(change.oldValue),
+      newValue: toStoredValue(change.newValue),
+    }
+  })
+
+  return result
+}
+
+function toStoredItems(items: { [key: string]: unknown }): { [key: string]: string } {
+  const result: { [key: string]: string } = {}
+
+  Object.entries(items).forEach(([key, value]) => {
+    if (typeof value === 'string') result[key] = value
+  })
+
+  return result
+}
+
 function fireStorageEvent(changes: { [key: string]: StorageChange }, area: Area) {
   listeners[area].forEach(listener => {
     listener(changes)
@@ -15,7 +50,7 @@ function fireStorageEvent(changes: { [key: string]: StorageChange }, area: Area)
 }
 
 chrome.storage.onChanged.addListener((changes, area) => {
-  fireStorageEvent(changes, area as Area)
+  fireStorageEvent(toStorageChanges(changes), area as Area)
 })
 
 function createOnChanged(area: Area): StorageChangeEvent {
@@ -35,7 +70,7 @@ function createOnChanged(area: Area): StorageChangeEvent {
 const createStorage = (storage: chrome.storage.StorageArea, area: Area): AsyncStorage => ({
   get: keys => new Promise(resolve => {
     storage.get(keys, items => {
-      resolve(items)
+      resolve(toStoredItems(items))
     })
   }),
   set: items => new Promise(resolve => {

--- a/src/storages/chrome-storage.ts
+++ b/src/storages/chrome-storage.ts
@@ -4,7 +4,7 @@ import { Area, createListenerRegistry, toStorageChanges, toStoredItems } from '.
 const registry = createListenerRegistry()
 
 chrome.storage.onChanged.addListener((changes, area) => {
-  registry.fire(toStorageChanges(changes), area as Area)
+  registry.fire(toStorageChanges(changes), area)
 })
 
 // chrome.storage is callback-based, unlike its promise-based firefox counterpart.

--- a/src/storages/chrome-storage.ts
+++ b/src/storages/chrome-storage.ts
@@ -1,72 +1,13 @@
-import { AsyncStorage, StorageChange, StorageChangeEvent, StorageChangeListener } from '../@types/storage'
+import { AsyncStorage } from '../@types/storage'
+import { Area, createListenerRegistry, toStorageChanges, toStoredItems } from '../utils/extension-storage'
 
-const listeners = {
-  local: new Set<StorageChangeListener>(),
-  sync: new Set<StorageChangeListener>(),
-  managed: new Set<StorageChangeListener>(),
-}
-
-type Area = keyof typeof listeners
-
-// chrome.storage holds arbitrary JSON, while this library only ever writes
-// serialized strings. Anything else under a key belongs to other code: it is
-// reported as absent rather than passed on as if this library had written it,
-// which is what the previous code did until it failed to parse.
-function toStoredValue(value: unknown): string | null | undefined {
-  if (value === undefined) return undefined
-
-  return typeof value === 'string' ? value : null
-}
-
-function toStorageChanges(
-  changes: { [key: string]: chrome.storage.StorageChange },
-): { [key: string]: StorageChange } {
-  const result: { [key: string]: StorageChange } = {}
-
-  Object.entries(changes).forEach(([key, change]) => {
-    result[key] = {
-      oldValue: toStoredValue(change.oldValue),
-      newValue: toStoredValue(change.newValue),
-    }
-  })
-
-  return result
-}
-
-function toStoredItems(items: { [key: string]: unknown }): { [key: string]: string } {
-  const result: { [key: string]: string } = {}
-
-  Object.entries(items).forEach(([key, value]) => {
-    if (typeof value === 'string') result[key] = value
-  })
-
-  return result
-}
-
-function fireStorageEvent(changes: { [key: string]: StorageChange }, area: Area) {
-  listeners[area].forEach(listener => {
-    listener(changes)
-  })
-}
+const registry = createListenerRegistry()
 
 chrome.storage.onChanged.addListener((changes, area) => {
-  fireStorageEvent(toStorageChanges(changes), area as Area)
+  registry.fire(toStorageChanges(changes), area as Area)
 })
 
-function createOnChanged(area: Area): StorageChangeEvent {
-  return {
-    addListener(listener) {
-      listeners[area].add(listener)
-    },
-    removeListener(listener) {
-      listeners[area].delete(listener)
-    },
-    hasListener(listener) {
-      return listeners[area].has(listener)
-    },
-  }
-}
-
+// chrome.storage is callback-based, unlike its promise-based firefox counterpart.
 const createStorage = (storage: chrome.storage.StorageArea, area: Area): AsyncStorage => ({
   get: keys => new Promise(resolve => {
     storage.get(keys, items => {
@@ -79,7 +20,7 @@ const createStorage = (storage: chrome.storage.StorageArea, area: Area): AsyncSt
   remove: keys => new Promise(resolve => {
     storage.remove(keys, resolve)
   }),
-  onChanged: createOnChanged(area),
+  onChanged: registry.createOnChanged(area),
 })
 
 const local = createStorage(chrome.storage.local, 'local')

--- a/src/utils/extension-storage.ts
+++ b/src/utils/extension-storage.ts
@@ -1,6 +1,14 @@
 import { StorageChange, StorageChangeEvent, StorageChangeListener } from '../@types/storage'
 
-export type Area = 'local' | 'sync' | 'managed'
+const TRACKED_AREAS = ['local', 'sync', 'managed'] as const
+
+export type Area = (typeof TRACKED_AREAS)[number]
+
+// Both browsers also report `session` changes, an area this library does not
+// expose. Dispatching one would read an undefined listener set and throw.
+function isTrackedArea(area: string): area is Area {
+  return (TRACKED_AREAS as readonly string[]).includes(area)
+}
 
 /**
  * Extension storage holds arbitrary JSON, while this library only ever writes
@@ -52,7 +60,9 @@ export function createListenerRegistry() {
   }
 
   return {
-    fire(changes: { [key: string]: StorageChange }, area: Area): void {
+    fire(changes: { [key: string]: StorageChange }, area: string): void {
+      if (!isTrackedArea(area)) return
+
       listeners[area].forEach(listener => {
         listener(changes)
       })

--- a/src/utils/extension-storage.ts
+++ b/src/utils/extension-storage.ts
@@ -1,0 +1,74 @@
+import { StorageChange, StorageChangeEvent, StorageChangeListener } from '../@types/storage'
+
+export type Area = 'local' | 'sync' | 'managed'
+
+/**
+ * Extension storage holds arbitrary JSON, while this library only ever writes
+ * serialized strings. Anything else under a key belongs to other code and is
+ * reported as absent — which is what effectively happened before, once such a
+ * value reached `JSON.parse` and the hook fell back to its initial value.
+ */
+export function toStoredValue(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined
+
+  return typeof value === 'string' ? value : null
+}
+
+export function toStorageChanges(
+  changes: { [key: string]: { oldValue?: unknown; newValue?: unknown } },
+): { [key: string]: StorageChange } {
+  const result: { [key: string]: StorageChange } = {}
+
+  Object.entries(changes).forEach(([key, change]) => {
+    result[key] = {
+      oldValue: toStoredValue(change.oldValue),
+      newValue: toStoredValue(change.newValue),
+    }
+  })
+
+  return result
+}
+
+export function toStoredItems(items: { [key: string]: unknown }): { [key: string]: string } {
+  const result: { [key: string]: string } = {}
+
+  Object.entries(items).forEach(([key, value]) => {
+    if (typeof value === 'string') result[key] = value
+  })
+
+  return result
+}
+
+/**
+ * Per-area subscriber registry shared by the extension adapters. Each adapter
+ * owns its own registry, so a change in one browser's storage never reaches
+ * listeners registered on another's.
+ */
+export function createListenerRegistry() {
+  const listeners: { [area in Area]: Set<StorageChangeListener> } = {
+    local: new Set<StorageChangeListener>(),
+    sync: new Set<StorageChangeListener>(),
+    managed: new Set<StorageChangeListener>(),
+  }
+
+  return {
+    fire(changes: { [key: string]: StorageChange }, area: Area): void {
+      listeners[area].forEach(listener => {
+        listener(changes)
+      })
+    },
+    createOnChanged(area: Area): StorageChangeEvent {
+      return {
+        addListener(listener) {
+          listeners[area].add(listener)
+        },
+        removeListener(listener) {
+          listeners[area].delete(listener)
+        },
+        hasListener(listener) {
+          return listeners[area].has(listener)
+        },
+      }
+    },
+  }
+}


### PR DESCRIPTION
`main` is currently broken — it does not build.

## What happened

`@types/chrome` 0.2.2 (#840) was merged while its CI was red. The bump itself is
correct, but it needs a source change that was not part of it:

```
TS2345: Type 'unknown' is not assignable to type 'string | null | undefined'
TS2345: '{ [key: string]: unknown }' is not assignable to '{ [key: string]: string }'
```

## The fix

Extension storage holds arbitrary JSON, while this library only ever writes
serialized strings — so the new types are accurate and the old assumption was
not. Values are narrowed **at the adapter boundary** instead of widening the
public `Storage` contract, keeping backend quirks out of the core.

Non-string values under a key belong to other code and are reported as absent.
That matches the previous outcome: such a value reached `JSON.parse`, threw, was
caught, and the hook fell back to its initial value. Same result, minus the
exception.

## And the duplication behind it

The two extension adapters were line-for-line copies — same listener registry,
same `fireStorageEvent`, same `createOnChanged`, same assembly of
local/sync/managed. Their only real difference is the access style: chrome is
callback-based, firefox is promise-based.

Fixing only the chrome copy would have left firefox to break identically the
moment its typings tighten, so the shared parts move to
`utils/extension-storage`. Each adapter keeps its own registry instance — a
change in one browser's storage still never reaches listeners registered on
another's — and keeps only its genuine difference. The narrowing now covers both.

| File | Before | After |
| --- | --- | --- |
| `chrome-storage.ts` | 93 lines | 34 |
| `browser-storage.ts` | 50 lines | 26 |
| `utils/extension-storage.ts` | — | 74 (shared) |

## Verification

| Gate | Before | After |
| --- | --- | --- |
| `npm run build` | fails (2 errors) | clean |
| `npm test` | fails to run | 66 passed |
| `npm run lint` | clean | clean |

Public API and hook behaviour are unchanged.

## Note on how this landed

Renovate merged this and two other PRs automatically without waiting for green
CI: `main` has no required status checks, and `renovate.json` still carries
`automerge: true` in its package rules plus `platformAutomerge: true` — an
incomplete disable from 2025-08-02, which removed only the top-level flag.
Repository auto-merge has since been switched back off. The missing required
checks and the renovate configuration are being addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser and extension storage handling by consistently normalizing stored values and change events.
  * Enhanced storage event listener management across local, sync, and managed storage areas.
  * Filtered unsupported storage values for more reliable reads and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->