### PR TITLE
ci: single dependency bot, quarantine, and an automated release

### DIFF
--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -12,16 +12,28 @@ tags:
 Jest with ts-jest and React Testing Library in a jsdom environment. Storage is mocked with
 `jest-localstorage-mock` and `jest-webextension-mock`.
 
-### A test must be proven able to fail
+### A test that cannot fail is worthless
 
-Before a test counts as coverage, watch it go **red** against the broken or unfixed code, then green
-after the fix. A test that passes both before and after the change tests nothing, and it is worse than
-no test, because it manufactures confidence.
+A test which stays green whether the behaviour works or not proves nothing, and is worse than no test
+because it manufactures confidence. Every test should be capable of failing for the reason it claims
+to check.
 
-For a bug fix this is not optional: write the test, run it against the unfixed code, keep the failure
-output, then fix. For a behaviour-preserving refactor the bar is different — there is no failure to
-produce, so the standard is that the entire existing suite is green before and after, with no test
-temporarily broken for ceremony.
+How far to go proving that is a judgement call, made per case rather than by ritual:
+
+- **Watch it go red first** when the failure is the point — a reported bug, a subtle condition, a
+  regression you are locking down. Seeing the exact failure is what proves the test aims at the real
+  defect and not next to it.
+- **Skip the ceremony** when the test plainly cannot pass by construction, or when the change is
+  mechanical and the assertion is obvious.
+- **Reach for a mutation audit** when false green is genuinely plausible — wide tolerances, assertions
+  that echo their own input, suites that might be running against the wrong branch, environment or
+  build. Break the code deliberately, confirm the test notices. Prefer someone other than the author
+  to run it.
+- **A behaviour-preserving refactor has no red phase at all.** The bar is the whole existing suite
+  green before and after, with nothing broken for ceremony.
+
+Judge which of these a change actually needs. Applying all of them to everything is as wrong as
+applying none.
 
 ### Never enshrine a bug as the contract
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    # A package published less than two weeks ago is not offered. Compromised
+    # releases are typically caught and unpublished within days, and this library
+    # gains nothing from being early. Security updates bypass the cooldown.
+    cooldown:
+      default-days: 14
+      semver-major-days: 14
+      semver-minor-days: 14
+      semver-patch-days: 14
+    groups:
+      # One pull request per toolchain instead of one per package: these move
+      # together and reviewing them apart wastes time.
+      types:
+        patterns:
+          - '@types/*'
+      jest:
+        patterns:
+          - jest
+          - jest-*
+          - ts-jest
+          - '@types/jest'
+      react:
+        patterns:
+          - react
+          - react-dom
+          - '@types/react'
+          - '@types/react-dom'
+          - '@testing-library/*'
+      build-tooling:
+        patterns:
+          - vite
+          - '@vitejs/*'
+          - typescript
+          - '@biomejs/*'
+      release-tooling:
+        patterns:
+          - release-it
+          - '@release-it/*'
+          - conventional-changelog-cli
+          - dotenv-cli
+    open-pull-requests-limit: 5
+    commit-message:
+      # Conventional commits drive the released version, so dependency updates
+      # must not read as features or fixes.
+      prefix: chore
+      prefix-development: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+# Manual rather than push-triggered: dependency updates land on main regularly,
+# and a push trigger would cut a release for each of them.
+on:
+  workflow_dispatch:
+    inputs:
+      increment:
+        description: 'Version increment. Leave as "auto" to derive it from conventional commits.'
+        required: false
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+        default: auto
+      dry-run:
+        description: 'Run the whole release without publishing or pushing anything.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  # Needed to commit the version bump, push the tag and create the release.
+  contents: write
+  # Needed for npm OIDC trusted publishing, which replaces a stored NPM_TOKEN.
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # @release-it/conventional-changelog derives the version from history.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.node-version'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Release
+        # NODE_AUTH_TOKEN is deliberately absent: npm falls back to the legacy
+        # token path whenever it is set, instead of using OIDC.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INCREMENT: ${{ inputs.increment }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          args=()
+          [ "$INCREMENT" != 'auto' ] && args+=("$INCREMENT")
+          [ "$DRY_RUN" = 'true' ] && args+=('--dry-run')
+          npx release-it "${args[@]}" --ci

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       ],
       "after:release": "echo Successfully released ${name} v${version} to ${repo.repository}."
     },
+    "npm": {
+      "skipChecks": true
+    },
     "plugins": {
       "@release-it/conventional-changelog": {
         "preset": "conventionalcommits",

--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "dependencyDashboard": true,
-  "dependencyDashboardTitle": "Dependency Dashboard",
-  "dependencyDashboardAutoclose": true,
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["minor"],
-      "matchCurrentVersion": "!/^0\\./",
-      "automerge": true
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor"],
-      "automerge": true
-    }
-  ],
-  "platformAutomerge": true,
-  "automergeType": "pr",
-  "automergeStrategy": "merge-commit"
+  "enabled": false,
+  "description": [
+    "Dependency updates are handled by Dependabot (.github/dependabot.yml).",
+    "Running both bots produces competing pull requests for the same dependency.",
+    "This file is kept rather than deleted: with no config present Renovate falls",
+    "back to its defaults and re-runs onboarding, so disabling has to be explicit."
+  ]
 }


### PR DESCRIPTION
Three things that belong together: one dependency bot instead of two, a 14-day
quarantine on updates, and a real release pipeline.

## One bot

Renovate and Dependabot were both active, which is why the same dependency
arrived twice — 12 open PRs from one against 6 from the other, competing on the
same lockfile. Running both is explicitly discouraged.

**Dependabot is kept.** For a single-package library, everything actually needed
here is native to it: cooldown, grouping, security updates. Renovate's strengths
— monorepos, 90+ ecosystems, fine-grained package rules — have nothing to apply
themselves to in a project with one runtime dependency, and cost an external app
plus a second configuration file to maintain.

The argument "Renovate is already configured" does not survive contact with the
current config: `automerge: true` in three package rules plus
`platformAutomerge: true` is exactly what merged a red-CI PR into `main` earlier
today. It needed rewriting either way.

Renovate is disabled **through its config, not by deleting it** — with no config
present it falls back to defaults and re-runs onboarding.

## 14-day quarantine

```yaml
cooldown:
  default-days: 14
  semver-major-days: 14
  semver-minor-days: 14
  semver-patch-days: 14
```

A package published less than two weeks ago is not offered. Compromised releases
are typically caught and unpublished within days, and this library gains nothing
from being early. **Security updates bypass the cooldown by design**, so CVE
fixes still arrive immediately.

Both bots support this — Dependabot gained `cooldown` in July 2025 — so it did
not decide the choice either way.

Updates are grouped per toolchain (types, jest, react, build, release) instead of
one PR per package, and commits are prefixed `chore`/`ci`: conventional commits
drive the released version here, so a dependency bump must never read as a
feature.

## Release

New manual workflow. release-it derives the version from conventional commits,
commits it, tags, publishes to npm and cuts a GitHub release.

Publishing uses **npm OIDC trusted publishing** rather than a stored
`NPM_TOKEN`: the workflow requests a short-lived signed token via
`id-token: write`, so no long-lived credential exists to leak or rotate, and npm
attaches provenance automatically.

Details that are easy to get wrong and are deliberate here:

- `NODE_AUTH_TOKEN` is **not** set — npm silently falls back to the legacy token
  path whenever it is present.
- `npm.skipChecks: true` — the `npm whoami` precheck cannot authenticate under OIDC.
- `fetch-depth: 0` — conventional-changelog needs the history to derive a version.
- Manual trigger — dependency updates land on `main` regularly, and a push
  trigger would cut a release for every one of them.

> [!NOTE]
> Publishing needs a one-time trusted publisher entry on npmjs.com for this
> package pointing at `release.yml`. Until it exists the release job will fail at
> the publish step; everything before it — version, changelog, tag — works.

## Also here

The testing rule is corrected: it demanded a red-first test for *every* fix and
treated mutation audits as a default. It now states the invariant — a test that
cannot fail is worthless — and leaves the depth of proof to the case.

## Verification

`npm run lint`, `npm test` (72 passed) and `npm run build` all clean.