### PR TITLE
docs: bring the repository up to open-source standard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something works differently from what is documented or expected
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+        Please do **not** use this form for security vulnerabilities — see [SECURITY.md](https://github.com/Akurganow/use-persisted-state/blob/main/SECURITY.md) instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected to happen instead.
+      placeholder: The hook returns the initial value even though a value is present in storage...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code sample or step-by-step instructions. A link to a repository or sandbox that reproduces the issue is even better.
+      placeholder: |
+        1. Create a factory with `createPersistedState('example', storage)`
+        2. ...
+    validations:
+      required: true
+  - type: dropdown
+    id: storage
+    attributes:
+      label: Storage adapter
+      description: Which storage backend does the bug occur with?
+      options:
+        - local-storage
+        - session-storage
+        - browser-storage (web extension)
+        - chrome-storage (web extension)
+        - custom adapter
+        - not storage-related / unsure
+    validations:
+      required: true
+  - type: input
+    id: library-version
+    attributes:
+      label: Library version
+      placeholder: e.g. 1.3.0
+    validations:
+      required: true
+  - type: input
+    id: react-version
+    attributes:
+      label: React version
+      placeholder: e.g. 19.1.1
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser and OS, or the runtime where the bug occurs (SSR framework, extension, etc.).
+      placeholder: e.g. Chrome 138 on macOS / Next.js 15 SSR
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that helps — console errors, storage contents, workarounds you found.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Akurganow/use-persisted-state/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately — never through public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Note that this package is deliberately small — a single runtime
+        dependency — so features that can live in a custom storage adapter usually should.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case, not only the solution — it helps to evaluate alternatives.
+      placeholder: I need to persist state that expires after a certain time...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? A sketch of the API is welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you tried or considered — including a custom storage adapter.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thank you for contributing! See CONTRIBUTING.md for setup and conventions. -->
+
+## Summary
+
+<!-- What does this change do, and why? Link the related issue if there is one, e.g. "Closes #123". -->
+
+## Type of change
+
+<!-- The Conventional Commits type determines the released version: fix -> patch, feat -> minor,
+     BREAKING CHANGE -> major; chore/docs/test/refactor/build/ci -> no release. -->
+
+- [ ] `fix` — bug fix (patch release)
+- [ ] `feat` — new feature (minor release)
+- [ ] Breaking change (major release; explained below)
+- [ ] `docs` / `test` / `refactor` / `chore` / `build` / `ci` — no release
+
+## Checklist
+
+- [ ] The PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format and the type matches the change
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes, with tests added or updated for behaviour changes
+- [ ] `npm run build` passes
+- [ ] Documentation (README, `docs/`) is updated if the public API or observable behaviour changed
+- [ ] No new runtime dependencies, no manual edits to `lib/`, `CHANGELOG.md` or the package version

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at me@akurganow.ru. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at me@akurganow.ru. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at a.kurganow@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to @plq/use-persisted-state
+
+Thank you for considering a contribution! This document explains how to set up the project, run
+the checks, and get a change merged.
+
+By participating you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+### Prerequisites
+
+- **Node.js** — the version used for development is pinned in [`.node-version`](.node-version);
+  version managers such as `fnm`, `nvm` or `asdf` pick it up automatically. The library itself
+  supports Node >= 16.
+- **npm** — the repository uses `package-lock.json`, so install with `npm ci`.
+
+### Setup
+
+```sh
+git clone https://github.com/Akurganow/use-persisted-state.git
+cd use-persisted-state
+npm ci
+```
+
+## Project layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/index.ts` | Public entry point |
+| `src/create-persisted-state.ts` | Synchronous hook factory |
+| `src/create-async-persisted-state.ts` | Asynchronous hook factory |
+| `src/storages/` | Bundled storage adapters |
+| `src/utils/` | Internal helpers |
+| `src/@types/` | Public type definitions |
+| `__tests__/` | Jest test suite |
+| `demo/` | Vite example app (not published) |
+| `docs/` | Documentation, including the [storage API](docs/storage-api.md) |
+| `lib/` | Build output produced by `tsc` — never edit it by hand |
+
+Everything under `src/` is public API that other projects depend on. A change to a signature or to
+observable behaviour — what the hook returns, when it re-renders, what lands in storage — affects
+consumers even when the type signature is untouched.
+
+## Development commands
+
+| Task | Command |
+| --- | --- |
+| Run tests | `npm test` |
+| Run tests in watch mode | `npm run test:watch` |
+| Lint (Biome) | `npm run lint` |
+| Lint and apply safe fixes | `npm run lint:fix` |
+| Format | `npm run format` |
+| Build the library | `npm run build` |
+| Build in watch mode | `npm run build:watch` |
+| Run the demo app | `npm run demo` |
+
+## Testing
+
+Tests live in `__tests__/` and run on Jest with `ts-jest` in a `jsdom` environment, using React
+Testing Library. Browser storage is mocked with `jest-localstorage-mock` and
+`jest-webextension-mock`.
+
+Guidelines:
+
+- Add or update tests for every behaviour change, and make sure each test can actually fail for
+  the reason it claims to check.
+- Cover both the synchronous and the asynchronous storage paths — they are separate
+  implementations with separate failure modes.
+- Drive hooks with `renderHook`; wrap state updates and async work in `act`.
+- Clean up between cases: some adapters keep module-level listener registries, so state can leak
+  across tests.
+
+## Commit convention
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/),
+and here that is load-bearing rather than cosmetic: the release tooling
+(`release-it` with `@release-it/conventional-changelog`) derives the released version and the
+changelog directly from commit messages. **A wrong type ships a wrong version to everyone who
+installs the package.**
+
+```
+<type>: <summary in present tense, not capitalised, no trailing period>
+```
+
+| Type | Effect on the release |
+| --- | --- |
+| `fix:` | patch |
+| `feat:` | minor |
+| `BREAKING CHANGE:` in the body/footer | major |
+| `chore:`, `docs:`, `test:`, `refactor:`, `build:`, `ci:` | no release |
+
+Use the body to explain **why** the change was made. The diff already shows what changed.
+
+## Proposing a change
+
+1. **Open an issue first** for new features or behaviour changes, so the approach can be discussed
+   before you invest time in an implementation. Small fixes can go straight to a pull request.
+2. **Fork and branch.** Branch off `main` with a lowercase, descriptive name — for example,
+   `fix-null-round-trip`, not `patch-2`.
+3. **Make the change.** Keep pull requests focused on a single concern. Do not add runtime
+   dependencies — the package deliberately has exactly one (`@plq/is`) and is chosen for being
+   small. Do not edit `lib/` (build output) or `CHANGELOG.md` (generated on release), and do not
+   bump the version in `package.json` — releases handle both.
+4. **Verify locally:** `npm run lint`, `npm test` and `npm run build` must all pass. CI runs the
+   same three steps on Linux, macOS and Windows for every pull request.
+5. **Open the pull request** against `main` and fill in the template. Keep the title in the
+   Conventional Commits format, since it determines the released version once merged.
+6. **Update documentation** (README, `docs/`) when the public API or observable behaviour changes.
+
+## Releases
+
+Releases are cut manually by maintainers via the GitHub Actions **Release** workflow, which runs
+`release-it`: the version and changelog are derived from the conventional commit history, and the
+package is published to npm. Contributors never need to publish anything.
+
+## Reporting bugs and security issues
+
+- Bugs and feature requests: use the [issue templates](https://github.com/Akurganow/use-persisted-state/issues/new/choose).
+- Security vulnerabilities: **do not open a public issue** — see [SECURITY.md](SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Uploadcare
+Copyright (c) 2019 Alex Kurganov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Alex Kurganov
+Copyright (c) 2019 Alexander Kurganov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # usePersistedState
-[![npm version](https://badge.fury.io/js/@plq%2Fuse-persisted-state.svg)](https://www.npmjs.com/package/@plq/use-persisted-state)
-[![Tests](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml)
 
-Persists the state to localStorage, sessionStorage or any custom storage
+[![npm version](https://badge.fury.io/js/@plq%2Fuse-persisted-state.svg)](https://www.npmjs.com/package/@plq/use-persisted-state)
+[![Tests](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+A React `useState` that persists to `localStorage`, `sessionStorage`, extension storage (`browser.storage` / `chrome.storage`), or any custom backend.
 
 ## Features
 
-- Persist the state to `localStorage`, `sessionStorage` or almost anything else implements [storage API](https://github.com/Akurganow/use-persisted-state/blob/master/docs/storage-api.md)
-- The state factory takes as many keys as needed, so you don't have to call the factory for each variable
-- Written with the TypeScript, the definitions go with the library
-- No third-party dependencies
+- Persist state to `localStorage`, `sessionStorage`, extension storage, or almost anything else that implements the [storage API](docs/storage-api.md)
+- One state factory serves as many keys as needed, so you don't have to call the factory for each variable
+- Supports both synchronous and asynchronous storage backends
+- Components using the same key stay in sync; with the `localStorage` adapter, changes also propagate across browser tabs
+- Written in TypeScript — type definitions ship with the package
+- A single tiny runtime dependency: [`@plq/is`](https://www.npmjs.com/package/@plq/is)
 
-## Example
+## Requirements
+
+To use `@plq/use-persisted-state`, you must use `react@16.8.0` or greater, which includes Hooks.
+The library is tested against React 19 and works with React 18.
+
+## Install
+
+```sh
+npm install @plq/use-persisted-state
+```
+
+## Quick start
 
 ```jsx
 import createPersistedState from '@plq/use-persisted-state'
@@ -32,22 +47,55 @@ export default function App() {
 }
 ```
 
-[![Edit @plq/use-persisted-state](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plquse-persisted-state-ob2od?fontsize=14)
+To try it locally, run the demo app from a repository checkout: `npm ci && npm run demo`.
 
-## Requirement
-To use `@plq/use-persisted-state`, you must use `react@16.8.0` or greater which includes Hooks.
-The library is fully compatible with React 18 and React 19.
+## API
 
-## React 19 Compatibility
+### `createPersistedState(name, storage)` — default export
 
-This library is fully compatible with React 19 and supports all new features:
-- Works seamlessly with `useTransition` for performance optimization
-- Compatible with `useActionState` for form handling
-- Supports `useOptimistic` for optimistic updates
+```ts
+const [usePersistedState, clear] = createPersistedState(name, storage)
+```
 
-Check out our [React 19 examples](./demo/src/examples/) to see these features in action!
+- `name` — a namespace for this factory. All keys created by the returned hook are stored together in a single storage entry named `persisted_state_hook:<name>`.
+- `storage` — a synchronous or asynchronous storage backend implementing the [storage API](docs/storage-api.md).
 
-## Clear Storage
+Returns a `[usePersistedState, clear]` tuple. The default export detects whether the backend is asynchronous by probing it: each of `get`, `set` and `remove` is called once (`get('')`, `set({})`, `remove('')`) to see whether it returns a `Promise`. If your backend must not be called during setup, import one of the named factories below instead — they skip detection entirely.
+
+### Named factories
+
+```ts
+import { createPersistedState, createAsyncPersistedState } from '@plq/use-persisted-state'
+```
+
+- `createPersistedState(name, storage)` — for synchronous backends only (`localStorage`, `sessionStorage`).
+- `createAsyncPersistedState(name, storage)` — for asynchronous backends only (`browser.storage`, `chrome.storage`, custom promise-based backends).
+
+### `usePersistedState(key, initialValue)`
+
+```ts
+const [state, setState] = usePersistedState(key, initialValue)
+```
+
+Works like `useState`: returns the current state and a setter that accepts either a value or an updater function (`prev => next`). In addition, every update is written to the storage backend, and external changes to the stored value update the state.
+
+- Values are serialized with `JSON.stringify`, so they must be JSON-serializable (no functions, class instances, `Map`, `Set`, etc.).
+- With an asynchronous backend, the hook renders `initialValue` first and updates once the stored value has loaded.
+
+### `clear()`
+
+Removes the factory's whole storage entry. Hooks created by that factory fall back to their initial values. Returns `void` for synchronous backends and `Promise<void>` for asynchronous ones.
+
+### TypeScript
+
+The package ships its own type definitions. When writing a custom backend, the storage contract types can be imported directly:
+
+```ts
+import type { Storage, AsyncStorage } from '@plq/use-persisted-state/lib/@types/storage'
+```
+
+## Clear storage
+
 ```jsx
 import createPersistedState from '@plq/use-persisted-state'
 import storage from '@plq/use-persisted-state/lib/storages/local-storage'
@@ -67,25 +115,30 @@ export default function App() {
   )
 }
 ```
+
 ## Use sessionStorage
+
 ```jsx
 import createPersistedState from '@plq/use-persisted-state'
 import storage from '@plq/use-persisted-state/lib/storages/session-storage'
 
 const [usePersistedState, clear] = createPersistedState('example', storage)
 ```
+
 ## Use async storage
+
 ```jsx
 import createPersistedState from '@plq/use-persisted-state'
-// or
+// or, to skip async detection:
 import { createAsyncPersistedState } from '@plq/use-persisted-state'
 import { local } from '@plq/use-persisted-state/lib/storages/browser-storage'
 
 const [usePersistedState, clear] = createPersistedState('example', local)
 ```
+
 ## Use custom storage
 
-The [storage API](https://github.com/Akurganow/use-persisted-state/blob/master/docs/storage-api.md) is similar to the browser.storage but with a few differences
+The [storage API](docs/storage-api.md) is similar to the WebExtensions `browser.storage` API, with a few differences.
 
 ```jsx
 import createPersistedState from '@plq/use-persisted-state'
@@ -100,9 +153,9 @@ onChangeSomeStorage(event => {
     },
   }
 
-  listeners.forEach(listener => {
+  for (const listener of storageListeners) {
     listener(changes)
-  })
+  }
 })
 
 const myStorage = {
@@ -118,16 +171,63 @@ const myStorage = {
 
 const [usePersistedState, clear] = createPersistedState('example', myStorage)
 ```
+
 ## Storage adapters
+
 ### [localStorage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) `@plq/use-persisted-state/lib/storages/local-storage`
-  - Useful for average web application
+
+- Useful for the average web application.
+- Synchronous. Changes made in other browser tabs are picked up through the [`storage` event](https://developer.mozilla.org/docs/Web/API/Window/storage_event).
+
 ### [sessionStorage](https://developer.mozilla.org/docs/Web/API/Window/sessionStorage) `@plq/use-persisted-state/lib/storages/session-storage`
-  - Useful for average web application
+
+- Useful for state that should not outlive the browser session.
+- Synchronous.
+
 ### [browser.storage](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage) `@plq/use-persisted-state/lib/storages/browser-storage`
-  - Only for web extensions.
-  - Don't forget to set up [polyfill](https://github.com/mozilla/webextension-polyfill) if you want to run extension in Chrome browser.
-  - To use this storage you need to include the "storage" [permission](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in your `manifest.json` file
-### [chrome.storage](https://developer.chrome.com/apps/storage) `@plq/use-persisted-state/lib/storages/chrome-storage`
-  - Only for Chrome-based web extensions.
-  - If you develop extension that will be run only in Chrome browser you can use this storage without [polyfill](https://github.com/mozilla/webextension-polyfill).
-  - You must declare the "storage" permission in the [extension manifest](https://developer.chrome.com/apps/manifest) to use this storage.
+
+- Only for web extensions. Asynchronous.
+- Named exports for each storage area: `local`, `sync` and `managed` (note that the [managed area](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed) is read-only for the extension).
+- Don't forget to set up the [polyfill](https://github.com/mozilla/webextension-polyfill) if you want to run the extension in a Chromium-based browser.
+- You need to declare the "storage" [permission](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) in your `manifest.json` file.
+
+### [chrome.storage](https://developer.chrome.com/docs/extensions/reference/api/storage) `@plq/use-persisted-state/lib/storages/chrome-storage`
+
+- Only for Chromium-based web extensions. Asynchronous.
+- Named exports for each storage area: `local`, `sync` and `managed` (the managed area is read-only for the extension).
+- If your extension runs only in Chromium-based browsers, you can use this adapter without the polyfill.
+- You must declare the "storage" permission in the [extension manifest](https://developer.chrome.com/docs/extensions/reference/manifest) to use this adapter.
+
+```jsx
+import createPersistedState from '@plq/use-persisted-state'
+import { local } from '@plq/use-persisted-state/lib/storages/chrome-storage'
+
+const [usePersistedState, clear] = createPersistedState('example', local)
+```
+
+## Server-side rendering
+
+This library targets browser environments and ships no SSR guards:
+
+- The bundled `local-storage` and `session-storage` adapters access `localStorage` / `sessionStorage` at import time, so importing them in an environment without these globals throws.
+- The synchronous hook reads from storage during render.
+
+When using an SSR framework (Next.js, Remix, etc.), make sure both the adapter import and the components using the hook run only on the client — for example, in client-only components or behind a dynamic import that is disabled during SSR.
+
+## How values are stored
+
+Each factory keeps all of its keys in a single storage entry named `persisted_state_hook:<name>`, holding a JSON object with one property per key:
+
+```
+persisted_state_hook:example → {"count":0}
+```
+
+Storage backends only ever see serialized strings. Anything you persist ends up unencrypted in the underlying storage — do not store secrets or sensitive data (see [SECURITY.md](SECURITY.md)).
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing and the commit convention, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://badge.fury.io/js/@plq%2Fuse-persisted-state.svg)](https://www.npmjs.com/package/@plq/use-persisted-state)
 [![Tests](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/Akurganow/use-persisted-state/actions/workflows/main.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B?logo=ko-fi&logoColor=white)](https://ko-fi.com/akurganow)
 
 A React `useState` that persists to `localStorage`, `sessionStorage`, extension storage (`browser.storage` / `chrome.storage`), or any custom backend.
 
@@ -18,7 +19,7 @@ A React `useState` that persists to `localStorage`, `sessionStorage`, extension 
 ## Requirements
 
 To use `@plq/use-persisted-state`, you must use `react@16.8.0` or greater, which includes Hooks.
-The library is tested against React 19 and works with React 18.
+The library is tested against React 19. The peer range allows React 16.8 and above, though only 19 is exercised in CI.
 
 ## Install
 
@@ -223,6 +224,17 @@ persisted_state_hook:example → {"count":0}
 ```
 
 Storage backends only ever see serialized strings. Anything you persist ends up unencrypted in the underlying storage — do not store secrets or sensitive data (see [SECURITY.md](SECURITY.md)).
+
+## Known issues
+
+These are defects, not intended behaviour, and are tracked for a fix. They are listed so you are
+not caught out by them in the meantime.
+
+- **`null` does not survive a round trip.** Setting a value to `null` writes it to storage, but on
+  the next read the hook falls back to the initial value instead of returning `null`. Use a
+  sentinel value if you need to represent "empty" today.
+- **`undefined` is not persisted.** `JSON.stringify` drops it, so the key disappears and the
+  initial value comes back.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,14 +13,14 @@ Only the latest release of `@plq/use-persisted-state` receives security fixes.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Report them privately by email to **me@akurganow.ru**. Include as much of the following as you
+Report them privately by email to **a.kurganow@gmail.com**. Include as much of the following as you
 can:
 
 - A description of the vulnerability and its impact.
 - Steps to reproduce, ideally with a minimal code sample.
 - The affected version(s) and environment.
 
-You should receive an acknowledgement within 7 days. Please allow time for the issue to be
+Reports are acknowledged as soon as they are seen. Please allow time for the issue to be
 investigated and fixed before any public disclosure; you will be credited in the fix release
 unless you prefer otherwise.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of `@plq/use-persisted-state` receives security fixes.
+
+| Version | Supported |
+| --- | --- |
+| latest 1.x | Yes |
+| older releases | No |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately by email to **me@akurganow.ru**. Include as much of the following as you
+can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, ideally with a minimal code sample.
+- The affected version(s) and environment.
+
+You should receive an acknowledgement within 7 days. Please allow time for the issue to be
+investigated and fixed before any public disclosure; you will be credited in the fix release
+unless you prefer otherwise.
+
+## Security considerations for users
+
+This library persists React state to a storage backend (`localStorage`, `sessionStorage`,
+extension storage, or a custom adapter) as plain, unencrypted JSON strings:
+
+- **Do not persist secrets** — tokens, passwords, personal data — through this hook. Anything
+  stored is readable by any code running on the same origin (or extension context).
+- Stored values are parsed with `JSON.parse` when read back. Data in storage can be modified by
+  other code on the page, so treat restored state as untrusted input and validate it in your
+  application when that matters.

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -70,7 +70,9 @@ reported without an `oldValue` is ignored.
 - **Values are strings.** The library serializes state with `JSON.stringify` before calling `set`
   and expects `get` to return exactly the strings that were stored. An adapter must not parse or
   transform values. If the underlying backend can hold non-string data (as extension storage can),
-  the adapter should report such foreign values as absent rather than widen the contract — see
+  the adapter should narrow rather than widen the contract: the bundled adapters omit foreign
+  values from `get`, and report them as `null` in `onChanged`, which the library reads as a
+  removal — see
   [`src/utils/extension-storage.ts`](../src/utils/extension-storage.ts) for how the bundled
   adapters do this.
 - **One entry per factory.** Each `createPersistedState(name, storage)` factory reads and writes a

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -1,22 +1,118 @@
-# Storage
+# Storage API
 
-Storage API is similar to the browser.storage but with a few differences
+A storage backend is a plain object the library talks to. The API is similar to the WebExtensions
+[`browser.storage`](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage) API,
+with a few differences.
+
+There are two variants of the contract, defined in
+[`src/@types/storage.ts`](../src/@types/storage.ts):
+
+- **`Storage`** — synchronous: methods return plain values.
+- **`AsyncStorage`** — asynchronous: the same methods return `Promise`s.
+
+The default `createPersistedState` export accepts either and detects which one it received;
+the named `createPersistedState` / `createAsyncPersistedState` factories each accept exactly one.
 
 ## Methods
-For async storage all methods should return `Promise`
-### get `(keys: string | string[]) => string | Promise<string>`
-Retrieves one or more items from the storage.
-### set `(items: { [k: string]: string }) => void | Promise<void>`
-Stores one or more items in the storage.
-### remove `(keys: string | string[]) => void | Promise<void>`
-Removes one or more items from the storage
+
+### `get(keys: string | string[]): { [key: string]: string }`
+
+Retrieves one or more items from the storage. Returns an object with one property per key that
+exists in the storage; keys without a stored value are simply absent from the result. For
+`AsyncStorage` the same object is returned wrapped in a `Promise`.
+
+### `set(items: { [key: string]: string }): void`
+
+Stores one or more items. Each property of `items` is a key/value pair to write. For
+`AsyncStorage` returns `Promise<void>`.
+
+### `remove(keys: string | string[]): void`
+
+Removes one or more items from the storage. For `AsyncStorage` returns `Promise<void>`.
 
 ## `onChanged`
-Fired when one or more items change
 
-### addListener
-Adds a listener to storage change event
-### removeListener
-Stop listening to storage change event. The `listener` argument is the listener to remove
-### hasListener
-Check whether `listener` is registered for this event. Returns true if it is listening, false otherwise
+An event object the library subscribes to so that hooks react to changes made outside of the
+current hook instance — by another component, another tab, or other code writing to the same
+backend.
+
+### `addListener(listener)`
+
+Adds a listener to the storage change event.
+
+### `removeListener(listener)`
+
+Stops listening to the storage change event. The `listener` argument is the listener to remove.
+
+### `hasListener(listener)`
+
+Checks whether `listener` is registered for this event. Returns `true` if it is listening,
+`false` otherwise.
+
+### Listener signature
+
+```ts
+type StorageChangeListener = (changes: { [key: string]: StorageChange }) => void
+
+interface StorageChange {
+  oldValue?: string | null
+  newValue?: string | null
+}
+```
+
+`changes` maps each changed storage key to its old and new values. When a key is removed, fire the
+listener with a `newValue` of `null` (or omit it) and the previous stored string in `oldValue` —
+the library treats that as a removal and resets affected hooks to their initial values. A removal
+reported without an `oldValue` is ignored.
+
+## Contract notes
+
+- **Values are strings.** The library serializes state with `JSON.stringify` before calling `set`
+  and expects `get` to return exactly the strings that were stored. An adapter must not parse or
+  transform values. If the underlying backend can hold non-string data (as extension storage can),
+  the adapter should report such foreign values as absent rather than widen the contract — see
+  [`src/utils/extension-storage.ts`](../src/utils/extension-storage.ts) for how the bundled
+  adapters do this.
+- **One entry per factory.** Each `createPersistedState(name, storage)` factory reads and writes a
+  single storage key, `persisted_state_hook:<name>`, containing a JSON object with one property per
+  hook key.
+- **Detection probes the backend.** The default export tells `Storage` and `AsyncStorage` apart by
+  calling `get('')`, `set({})` and `remove('')` once and checking whether the results are
+  `Promise`s. If probing your backend is undesirable, use the named factories, which skip
+  detection.
+
+## Example
+
+```js
+const storageListeners = new Set()
+
+onChangeSomeStorage(event => {
+  const changes = {
+    [event.key]: {
+      newValue: event.newValue,
+      oldValue: event.oldValue,
+    },
+  }
+
+  for (const listener of storageListeners) {
+    listener(changes)
+  }
+})
+
+const myStorage = {
+  get: keys => getItemsFromSomeStorage(keys),
+  set: items => setItemsToSomeStorage(items),
+  remove: keys => removeItemsFromSomeStorage(keys),
+  onChanged: {
+    addListener: listener => storageListeners.add(listener),
+    removeListener: listener => storageListeners.delete(listener),
+    hasListener: listener => storageListeners.has(listener),
+  },
+}
+```
+
+TypeScript users can import the contract types directly:
+
+```ts
+import type { Storage, AsyncStorage } from '@plq/use-persisted-state/lib/@types/storage'
+```


### PR DESCRIPTION
README, contribution docs, security policy, templates — plus fixes to things
that were quietly wrong for years.

## What was actually broken

**`LICENSE` carried someone else's copyright.** It said `Copyright (c) 2017
Uploadcare` — copied in from another project and published with every release
since. Now `Copyright (c) 2019 Alexander Kurganov`, matching the first commit
(2019-09-04) and the package author.

**The security contact reached nobody.** `me@akurganow.ru` — that domain no
longer exists. A vulnerability report sent there vanished silently, which is
worse than having no policy at all, because the reporter believes they have told
someone.

**README claimed "No third-party dependencies"** while `@plq/is` sits in
`dependencies`.

**Documented React support was a guess.** "Works with React 18" — CI only ever
runs React 19.

**`docs/storage-api.md` had wrong signatures** — `get` was described as
returning a `string`, where the type requires `{ [key: string]: string }`.

## Added

| File | Purpose |
| --- | --- |
| `CONTRIBUTING.md` | setup, commands, the conventional-commit-to-version mapping, PR process |
| `SECURITY.md` | private reporting, plus a warning not to store secrets — values sit in storage as plain JSON |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `.github/ISSUE_TEMPLATE/` | bug report and feature request forms, blank issues off |
| `.github/PULL_REQUEST_TEMPLATE.md` | checklist including version impact |

## README

Rewritten around what the code actually does: the full API surface (default
export with backend auto-detection, both named exports, `clear` semantics), the
extension adapters and their `local`/`sync`/`managed` exports, the storage
format (`persisted_state_hook:<name>`), SSR caveats (adapters touch
`localStorage` at import time), and the fact that auto-detection *probes* the
storage it is handed with `get('')`, `set({})` and `remove('')`.

Badges now point at `main` rather than the non-existent `master`, and Ko-fi
replaces the dead Patreon link.

## Known issues, stated as defects

A new section documents that `null` and `undefined` do not survive a round trip.
Both are bugs, not contract — the project's testing rule forbids writing a defect
down as intended behaviour, so they are labelled as awaiting a fix rather than
described as how the hook works.

## Review

Written by one agent, then reviewed by a second that checked every claim against
the source: imports resolve, exported names exist, signatures match
`src/@types/storage.ts`, commands match `package.json`, template YAML parses and
its labels exist. The review found the dead contact as a blocker and three
overclaims; all are fixed here. Its verdict on the rest: accurate.

`npm run lint`, `npm run typecheck`, `npm test` (72 passed) and `npm run build`
all clean.