### PR TITLE
Stop concurrent and unreadable-entry writes from losing data

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,14 @@ updates:
           - release-it
           - '@release-it/*'
           - dotenv-cli
+    ignore:
+      # ts-jest@29.4.12 declares `"typescript": ">=4.3 <7"`, so the tool the whole
+      # test suite runs on rules the 7 line out itself: taking it would need
+      # `--legacy-peer-deps` or an `overrides` entry, and neither is allowed here.
+      # Remove this once ts-jest widens that range.
+      - dependency-name: typescript
+        update-types:
+          - 'version-update:semver-major'
     open-pull-requests-limit: 5
     commit-message:
       # Conventional commits drive the released version, so dependency updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
 * stop the hook overwriting its own state and reading storage on every render ([256f06d](https://github.com/Akurganow/use-persisted-state/commit/256f06dce7dace4ebc6698795a79846baeeb0343))
 * **storages:** ignore storage areas the library does not track ([c4b3c9f](https://github.com/Akurganow/use-persisted-state/commit/c4b3c9f3222ad47c01f2885a6e5bdbf19c81bfb0)), references [#938](https://github.com/Akurganow/use-persisted-state/issues/938)
 
+### Behaviour note: `NaN` and `Infinity`
+
+A stored `NaN` or `Infinity` now reads back as `null` instead of falling back to the initial value.
+
+`JSON.stringify` writes `null`, `NaN` and `Infinity` all as `null`, so the read side cannot tell
+them apart. Returning the initial value for `null` was what stopped a genuinely stored `null` from
+round-tripping, and fixing that necessarily gives up the fallback for the other two.
+
+This ships in a minor release deliberately. A `NaN` or an `Infinity` reaching storage is a defect in
+the calling code; the old fallback did not repair it, it only hid it. If your code can produce
+either, guard the value before writing it.
+
 ## [1.3.0](https://github.com/Akurganow/use-persisted-state/compare/v1.2.0...v1.3.0) (2025-08-02)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -228,10 +228,16 @@ Storage backends only ever see serialized strings. Anything you persist ends up 
 ### An entry the library cannot read
 
 A write replaces the factory's whole entry, so there is nothing safe to store when the entry already
-there will not parse, or parses to something that is not an object — another library writing under
-the same key, or a write cut short. The setter reports the failure on `console.error`, keeps the
-value you set in memory and writes nothing, leaving every other hook's key exactly where it is. The
-factory's `clear` removes the entry and lets writing resume.
+there is a string that will not parse, or parses to something that is not an object — another
+library writing under the same key, or a write cut short. The setter reports the failure on
+`console.error`, keeps the value you set in memory and writes nothing, leaving every other hook's
+key exactly where it is. The factory's `clear` removes the entry and lets writing resume.
+
+This reaches as far as the adapter reports. Web storage holds only strings, so anything under the
+key comes back and is checked. Extension storage holds arbitrary JSON, and the bundled adapters
+report a non-string value as absent — the library then reads the entry as empty and its next write
+**replaces that value**. Storing your own data under a `persisted_state_hook:` key in extension
+storage is not safe, whatever its type.
 
 ### Values JSON cannot carry
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ persisted_state_hook:example → {"count":0}
 
 Storage backends only ever see serialized strings. Anything you persist ends up unencrypted in the underlying storage — do not store secrets or sensitive data (see [SECURITY.md](https://github.com/Akurganow/use-persisted-state/blob/main/SECURITY.md)).
 
+### An entry the library cannot read
+
+A write replaces the factory's whole entry, so there is nothing safe to store when the entry already
+there will not parse, or parses to something that is not an object — another library writing under
+the same key, or a write cut short. The setter reports the failure on `console.error`, keeps the
+value you set in memory and writes nothing, leaving every other hook's key exactly where it is. The
+factory's `clear` removes the entry and lets writing resume.
+
 ### Values JSON cannot carry
 
 A few values do not survive `JSON.stringify`. This follows from the format rather than from a choice

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -232,6 +232,31 @@ describe('changing key', () => {
 
     expect(result.current[0]).toBe('value-second')
   })
+
+  test('loads the new key after the previous one has already applied a value', async () => {
+    const { asyncStorage } = createFakeAsyncStorage({
+      'persisted_state_hook:appliedKeys': JSON.stringify({ first: 'value-first', second: 'value-second' }),
+    })
+    const [useKeyedPersistedState] = createAsyncPersistedState('appliedKeys', asyncStorage)
+
+    const { result, rerender } = renderHook(({ itemKey }) => useKeyedPersistedState(itemKey, 'initial'), {
+      initialProps: { itemKey: 'first' },
+    })
+
+    await act(async () => {})
+
+    // The load for the first key has applied, which is the state the second load has to be able
+    // to overrule. The flag that stops a late load reverting a value the caller set belongs to
+    // the key it was raised for; carried across, it shuts the new key's load out for good and the
+    // hook shows the previous key's value under the new key.
+    expect(result.current[0]).toBe('value-first')
+
+    rerender({ itemKey: 'second' })
+
+    await act(async () => {})
+
+    expect(result.current[0]).toBe('value-second')
+  })
 })
 
 describe('setter identity', () => {
@@ -367,6 +392,24 @@ describe('concurrent writers on one factory', () => {
 
 describe('own writes', () => {
   const entryKey = 'persisted_state_hook:echoes'
+
+  test('keeps the value it was given rather than the storage round-trip of it', async () => {
+    // This backend reports the change inside the `set` that made it, which is the arrangement
+    // that proves the record is taken before the write rather than after.
+    const { asyncStorage } = createFakeAsyncStorage()
+    const [useOwnState] = createAsyncPersistedState('own', asyncStorage)
+    const { result } = renderHook(() => useOwnState<{ count: number }>('own', { count: 0 }))
+    const applied = { count: 1 }
+
+    await act(async () => {
+      await result.current[1](applied)
+    })
+
+    // Decoding the echo yields an equal object with a new identity, so an unsuppressed echo hands
+    // the caller something it did not set and re-renders for it. Identity is what shows that,
+    // where a value assertion passes either way.
+    expect(result.current[0]).toBe(applied)
+  })
 
   test('suppresses every echo it is still waiting for, not only the last', async () => {
     const stored: { [key: string]: string } = {}
@@ -521,5 +564,28 @@ describe('a backend that rejects a write', () => {
     // promise rather than from the rejected one: chained onto the rejection it would stay pending
     // for ever, so one failed write would silently stop every later write on the factory.
     expect(JSON.parse(stored[entryKey])).toEqual({ value: 'second' })
+  })
+})
+
+describe('clearing', () => {
+  const entryKey = 'persisted_state_hook:cleared'
+
+  test('is not undone by a write already on its way to storage', async () => {
+    const { asyncStorage, stored } = createFakeAsyncStorage()
+    const [useDraftState, clearDrafts] = createAsyncPersistedState('cleared', asyncStorage)
+    const { result } = renderHook(() => useDraftState<string>('draft', 'initial'))
+
+    await act(async () => {
+      // Requested while a write is still in flight, which is what the button doing it competes
+      // with in practice. Outside the chain the removal runs first and the write lands after it,
+      // putting back what was asked to be gone - and "clear this data" is the one request that
+      // must not half happen.
+      const write = result.current[1]('typed just before')
+      const cleared = clearDrafts()
+
+      await Promise.all([write, cleared])
+    })
+
+    expect(stored[entryKey]).toBeUndefined()
   })
 })

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -14,7 +14,8 @@ type DeferredResolve = () => void
  * `deferredReads` holds back that many leading `get` calls until `releaseReads`
  * is called, which is how a slow backend is reproduced. Deferring only the
  * leading reads keeps the setter's own read fast, so a late load cannot be
- * masked by the change event the setter's write emits.
+ * masked by the change event the setter's write emits. `stored` is the backing
+ * object itself, so a case can read what actually reached storage.
  */
 function createFakeAsyncStorage(entries: { [key: string]: string } = {}, deferredReads = 0) {
   const stored: { [key: string]: string } = { ...entries }
@@ -85,7 +86,7 @@ function createFakeAsyncStorage(entries: { [key: string]: string } = {}, deferre
     }
   }
 
-  return { asyncStorage, get, releaseReads }
+  return { asyncStorage, get, releaseReads, stored }
 }
 
 describe('hook defined correctly', () => {
@@ -309,5 +310,58 @@ describe('a backend that fails the read', () => {
     // library's own message keeps React's logging from satisfying this.
     expect(consoleError).toHaveBeenCalledWith("use-persisted-state: Can't read value from storage", expect.any(Error))
     expect(result.current[0]).toBe('initial')
+  })
+})
+
+describe('an entry the hook cannot read', () => {
+  const entryKey = 'persisted_state_hook:damagedAsync'
+  let consoleError: jest.SpyInstance
+
+  beforeEach(() => {
+    cleanup()
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  test('is left in storage rather than replaced by the next write', async () => {
+    // Truncated rather than garbage on purpose: alpha and beta are still legible in the bytes,
+    // and only a write that replaces them makes the loss permanent.
+    const damagedEntry = '{"alpha":"one","beta":"two"'
+    const { asyncStorage, stored } = createFakeAsyncStorage({ [entryKey]: damagedEntry })
+    const [useDamagedState] = createAsyncPersistedState('damagedAsync', asyncStorage)
+    const { result } = renderHook(() => useDamagedState('gamma', 'initial'))
+
+    await act(async () => {
+      await result.current[1]('three')
+    })
+
+    // The write is refused, not the update: the caller keeps what it set, and hears why it did
+    // not persist.
+    expect(result.current[0]).toBe('three')
+    expect(stored[entryKey]).toBe(damagedEntry)
+    expect(consoleError).toHaveBeenCalledWith("use-persisted-state: Can't write value to storage", expect.any(Error))
+  })
+
+  test('does not reject the setter, and lets the writes that follow land', async () => {
+    const { asyncStorage, stored } = createFakeAsyncStorage({ [entryKey]: '{"alpha":"one"' })
+    const [useDamagedState] = createAsyncPersistedState('damagedAsync', asyncStorage)
+    const { result } = renderHook(() => useDamagedState('gamma', 'initial'))
+
+    // A refusal that reached the caller as a rejection would be an unhandled rejection in every
+    // consumer that treats the setter as `useState`'s, and those end the process on Node 15+.
+    await act(async () => {
+      await result.current[1]('refused')
+    })
+
+    stored[entryKey] = JSON.stringify({ alpha: 'one' })
+
+    await act(async () => {
+      await result.current[1]('accepted')
+    })
+
+    expect(JSON.parse(stored[entryKey])).toEqual({ alpha: 'one', gamma: 'accepted' })
   })
 })

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -313,6 +313,117 @@ describe('a backend that fails the read', () => {
   })
 })
 
+describe('concurrent writers on one factory', () => {
+  const entryKey = 'persisted_state_hook:concurrent'
+
+  // An in-memory AsyncStorage supplied through the same extension point consumers use. Its
+  // promises resolve immediately: no artificial delay is needed, because awaiting at all is
+  // enough to let a second writer read before the first one has written.
+  function createMemoryStorage() {
+    const entries = new Map<string, string>()
+
+    const memoryStorage: AsyncStorage = {
+      get: async keys => {
+        const key = Array.isArray(keys) ? keys[0] : keys
+        const value = entries.get(key)
+
+        return value === undefined ? {} : { [key]: value }
+      },
+      set: async items => {
+        for (const [key, value] of Object.entries(items)) entries.set(key, value)
+      },
+      remove: async keys => {
+        for (const key of Array.isArray(keys) ? keys : [keys]) entries.delete(key)
+      },
+      onChanged: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        hasListener: () => false,
+      },
+    }
+
+    return { storage: memoryStorage, readEntry: () => entries.get(entryKey) }
+  }
+
+  test('should keep both keys when two hooks write at the same time', async () => {
+    const memory = createMemoryStorage()
+    const [useConcurrentState] = createAsyncPersistedState('concurrent', memory.storage)
+
+    const alpha = renderHook(() => useConcurrentState<string>('alpha', 'initial'))
+    const beta = renderHook(() => useConcurrentState<string>('beta', 'initial'))
+
+    await act(async () => {
+      // Started together on purpose: the setter reads the entry, awaits, then writes it back
+      // whole, so a second writer entering that window carries a snapshot taken before the
+      // first one landed.
+      await Promise.all([alpha.result.current[1]('one'), beta.result.current[1]('two')])
+    })
+
+    // Both keys belong to the same entry and neither writer knows about the other. How the
+    // overlap is avoided is open; that no committed write disappears is not.
+    expect(JSON.parse(memory.readEntry() ?? '{}')).toEqual({ alpha: 'one', beta: 'two' })
+  })
+})
+
+describe('own writes', () => {
+  const entryKey = 'persisted_state_hook:echoes'
+
+  test('suppresses every echo it is still waiting for, not only the last', async () => {
+    const stored: { [key: string]: string } = {}
+    const listeners = new Set<StorageChangeListener>()
+    const heldEchoes: Array<() => void> = []
+
+    // A backend free to report a change after the write it reports has settled, as the extension
+    // backends are. Holding the echoes until both writes have landed is what puts the second
+    // write's record in place before the first write's echo arrives.
+    const lateNotifyingStorage: AsyncStorage = {
+      get: async keys => {
+        const key = Array.isArray(keys) ? keys[0] : keys
+
+        return key in stored ? { [key]: stored[key] } : {}
+      },
+      set: async items => {
+        const changes: { [key: string]: StorageChange } = {}
+
+        for (const [key, value] of Object.entries(items)) {
+          changes[key] = { oldValue: stored[key] ?? null, newValue: value }
+          stored[key] = value
+        }
+
+        heldEchoes.push(() => {
+          for (const listener of [...listeners]) listener(changes)
+        })
+      },
+      remove: async () => undefined,
+      onChanged: {
+        addListener: listener => {
+          listeners.add(listener)
+        },
+        removeListener: listener => {
+          listeners.delete(listener)
+        },
+        hasListener: listener => listeners.has(listener),
+      },
+    }
+    const [useEchoState] = createAsyncPersistedState('echoes', lateNotifyingStorage)
+    const { result } = renderHook(() => useEchoState<string>('value', 'initial'))
+
+    await act(async () => {
+      await result.current[1]('first')
+      await result.current[1]('second')
+    })
+
+    await act(async () => {
+      for (const echo of heldEchoes) echo()
+    })
+
+    // One record held only the latest write, so the first write's echo arrived unclaimed, was
+    // read as somebody else's write and put the earlier value back over the later one.
+    expect(result.current[0]).toBe('second')
+    expect(stored[entryKey]).toBe(JSON.stringify({ value: 'second' }))
+  })
+})
+
 describe('an entry the hook cannot read', () => {
   const entryKey = 'persisted_state_hook:damagedAsync'
   let consoleError: jest.SpyInstance
@@ -363,5 +474,52 @@ describe('an entry the hook cannot read', () => {
     })
 
     expect(JSON.parse(stored[entryKey])).toEqual({ alpha: 'one', gamma: 'accepted' })
+  })
+})
+
+describe('a backend that rejects a write', () => {
+  const entryKey = 'persisted_state_hook:flaky'
+
+  test('keeps the entry writable for the calls behind the one that failed', async () => {
+    const stored: { [key: string]: string } = {}
+    let shouldRejectWrite = true
+
+    const flakyStorage: AsyncStorage = {
+      get: async keys => {
+        const key = Array.isArray(keys) ? keys[0] : keys
+
+        return key in stored ? { [key]: stored[key] } : {}
+      },
+      set: async items => {
+        if (shouldRejectWrite) {
+          shouldRejectWrite = false
+
+          throw new Error('write rejected')
+        }
+
+        Object.assign(stored, items)
+      },
+      remove: async () => undefined,
+      onChanged: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        hasListener: () => false,
+      },
+    }
+    const [useFlakyState] = createAsyncPersistedState('flaky', flakyStorage)
+    const { result } = renderHook(() => useFlakyState<string>('value', 'initial'))
+
+    await act(async () => {
+      await expect(result.current[1]('first')).rejects.toThrow('write rejected')
+    })
+
+    await act(async () => {
+      await result.current[1]('second')
+    })
+
+    // Writes on one entry run one at a time, and the next one has to start from the settled
+    // promise rather than from the rejected one: chained onto the rejection it would stay pending
+    // for ever, so one failed write would silently stop every later write on the factory.
+    expect(JSON.parse(stored[entryKey])).toEqual({ value: 'second' })
   })
 })

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -413,10 +413,10 @@ describe('an entry the hook cannot read', () => {
 
   test('survives a write when it is a foreign JSON value', () => {
     // A bare `null` did not merely lose the write, it threw out of the setter and into whatever
-    // called it, which for a consumer is a click handler. `act` absorbs a throw raised once an
-    // update is queued, so the case has to catch it itself: asserting only the storage would
-    // pass on the defect, whose crash leaves the entry untouched for the same reason a refusal
-    // does.
+    // called it, which for a consumer is a click handler. Catching that throw here is the whole
+    // point of the case: a crashing setter leaves the entry untouched for the same reason a
+    // refusal does, so the storage assertion below holds either way and proves nothing on its
+    // own. What separates the two is whether the caller was handed an exception.
     localStorage.setItem(entryKey, 'null')
 
     const { result } = renderHook(() => usePersistedState('gamma', 'initial'))

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -333,3 +333,63 @@ describe('storage access', () => {
     expect(get.mock.calls.length).toBe(readsAfterMount)
   })
 })
+
+describe('an entry the hook cannot read', () => {
+  const entryKey = 'persisted_state_hook:damaged'
+  const [usePersistedState] = createPersistedState('damaged', storage)
+  let consoleError: jest.SpyInstance
+
+  beforeEach(() => {
+    cleanup()
+    localStorage.clear()
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  test('is left in storage rather than replaced by the next write', () => {
+    // Truncated rather than garbage on purpose: alpha and beta are still legible in the bytes,
+    // and only a write that replaces them makes the loss permanent.
+    const damagedEntry = '{"alpha":"one","beta":"two"'
+
+    localStorage.setItem(entryKey, damagedEntry)
+
+    const { result } = renderHook(() => usePersistedState('gamma', 'initial'))
+
+    act(() => {
+      result.current[1]('three')
+    })
+
+    // The write is refused, not the update: the caller keeps what it set, and hears why it did
+    // not persist.
+    expect(result.current[0]).toBe('three')
+    expect(localStorage.__STORE__[entryKey]).toBe(damagedEntry)
+    expect(consoleError).toHaveBeenCalledWith("use-persisted-state: Can't write value to storage", expect.any(Error))
+  })
+
+  test('survives a write when it is a foreign JSON value', () => {
+    // A bare `null` did not merely lose the write, it threw out of the setter and into whatever
+    // called it, which for a consumer is a click handler. `act` absorbs a throw raised once an
+    // update is queued, so the case has to catch it itself: asserting only the storage would
+    // pass on the defect, whose crash leaves the entry untouched for the same reason a refusal
+    // does.
+    localStorage.setItem(entryKey, 'null')
+
+    const { result } = renderHook(() => usePersistedState('gamma', 'initial'))
+    let thrownBySetter: unknown = null
+
+    act(() => {
+      try {
+        result.current[1]('three')
+      } catch (err) {
+        thrownBySetter = err
+      }
+    })
+
+    expect(thrownBySetter).toBeNull()
+    expect(result.current[0]).toBe('three')
+    expect(localStorage.__STORE__[entryKey]).toBe('null')
+  })
+})

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -334,6 +334,48 @@ describe('storage access', () => {
   })
 })
 
+describe('concurrent writers on one factory', () => {
+  test('keeps both keys when two hooks write in the same tick', () => {
+    const entryKey = 'persisted_state_hook:syncConcurrent'
+    const entries = new Map<string, string>()
+
+    const memoryStorage: StorageAdapter = {
+      get: keys => {
+        const key = Array.isArray(keys) ? keys[0] : keys
+        const value = entries.get(key)
+
+        return value === undefined ? {} : { [key]: value }
+      },
+      set: items => {
+        for (const [key, value] of Object.entries(items)) entries.set(key, value)
+      },
+      remove: keys => {
+        for (const key of Array.isArray(keys) ? keys : [keys]) entries.delete(key)
+      },
+      onChanged: {
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        hasListener: () => false,
+      },
+    }
+
+    const [useConcurrentState] = createPersistedState('syncConcurrent', memoryStorage)
+    const alpha = renderHook(() => useConcurrentState<string>('alpha', 'initial'))
+    const beta = renderHook(() => useConcurrentState<string>('beta', 'initial'))
+
+    act(() => {
+      alpha.result.current[1]('one')
+      beta.result.current[1]('two')
+    })
+
+    // The asynchronous factory loses one of these: its setter awaits between reading the entry
+    // and writing it back, so a second writer starts from a snapshot taken before the first one
+    // landed. Here the read, the merge and the write run with nothing in between. Keeping that
+    // difference as a case rather than as a measurement is what stops it being rediscovered.
+    expect(JSON.parse(entries.get(entryKey) ?? '{}')).toEqual({ alpha: 'one', beta: 'two' })
+  })
+})
+
 describe('an entry the hook cannot read', () => {
   const entryKey = 'persisted_state_hook:damaged'
   const [usePersistedState] = createPersistedState('damaged', storage)

--- a/__tests__/get-new-item.test.ts
+++ b/__tests__/get-new-item.test.ts
@@ -25,13 +25,48 @@ describe('get-new-item', function () {
     )
   })
 
-  it('should console.error if not valid persistedItem', function () {
-    expect(getNewItem<string>('key', 'foo: bar', 'baz')).toEqual(
-      JSON.stringify({
-        key: 'baz',
-      }),
-    )
+  it('should report and refuse an entry it cannot parse', function () {
+    // This used to answer with `{"key":"baz"}` and report it. The caller writes what comes back
+    // over the whole entry, so that answer replaced every other hook's key with nothing and took
+    // the bytes a repair still needed with it.
+    expect(() => getNewItem<string>('key', 'foo: bar', 'baz')).toThrow(SyntaxError)
 
     expect(console.error).toHaveBeenCalled()
+  })
+
+  it('should report and refuse an entry that is not an object of keys', function () {
+    // Any JSON can end up under a factory's key, and merging into a value that is not an object
+    // of keys never produced one: a number or a string came back out of `JSON.stringify` as
+    // itself, an array stayed an array, and `null` threw out of `Object.assign` into the caller.
+    // All four lost the value being set, three of them silently.
+    for (const foreignEntry of ['5', '"text"', '[1,2]', 'null']) {
+      expect(() => getNewItem<string>('key', foreignEntry, 'baz')).toThrow(TypeError)
+    }
+
+    expect(console.error).toHaveBeenCalledTimes(4)
+  })
+
+  it('should not discard the other keys of an entry it cannot parse', function () {
+    // A factory keeps all of its hooks in one storage entry, so what this function returns for a
+    // damaged entry is written over every key in it, not just the one being set. Truncated rather
+    // than garbage on purpose: the other keys are still legible in the bytes, and only a write
+    // that replaces them makes the loss permanent.
+    const damagedEntry = '{"alpha":"one","beta":"two"'
+    let written: string | undefined
+
+    try {
+      written = getNewItem<string>('gamma', damagedEntry, 'three')
+    } catch {
+      // Refusing outright is an acceptable answer to a damaged entry — the bytes stay where a
+      // repair can still reach them, and nothing is written over them.
+      written = undefined
+    }
+
+    // Anything that does come back is going to be written over the whole entry, so it has to
+    // carry the keys that were in it. Naming the one payload this used to return would let an
+    // empty object or an empty string through, and those lose the writing hook's key as well.
+    if (written !== undefined) {
+      expect(JSON.parse(written)).toMatchObject({ alpha: 'one', beta: 'two' })
+    }
   })
 })

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { renderHook, act } from '@testing-library/react'
-import useStorageHandler from '../../src/utils/use-storage-handler'
+import useStorageHandler, { recordOwnWrite } from '../../src/utils/use-storage-handler'
 import type { Storage, StorageChange, StorageChangeListener } from '../../src/@types/storage'
 
 const storageKey = 'persisted_state_hook:test'
@@ -176,6 +176,63 @@ describe('use-storage-handler', () => {
     })
   })
 
+  test('follows the key the hook is rendering for after it changes', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+    const pendingOwnWrites = createOwnWriteRecord()
+
+    const { rerender } = renderHook(
+      ({ renderedKey }) =>
+        useStorageHandler<string>(renderedKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
+      { initialProps: { renderedKey: 'first' } },
+    )
+
+    rerender({ renderedKey: 'second' })
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: JSON.stringify({ first: 'FIRST', second: 'SECOND' }) } })
+    })
+
+    // A listener left subscribed for the key the hook mounted with reads the wrong property out
+    // of every entry that arrives afterwards, and hands the caller another key's value.
+    expect(applyValue).toHaveBeenCalledWith('SECOND')
+    expect(applyValue).not.toHaveBeenCalledWith('FIRST')
+  })
+
+  test('ignores a change reported for another factory entry', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+    const pendingOwnWrites = createOwnWriteRecord()
+
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+
+    // Factories share a backend, and its listeners hear about every key in it. An entry of
+    // another factory can hold this hook's item key and mean something entirely different.
+    act(() => {
+      fire({
+        'persisted_state_hook:elsewhere': { oldValue: null, newValue: JSON.stringify({ [itemKey]: 'not ours' }) },
+      })
+    })
+
+    expect(applyValue).not.toHaveBeenCalled()
+  })
+
+  test('does not restore the initial value for a removal that reports nothing removed', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+    const pendingOwnWrites = createOwnWriteRecord()
+
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+
+    // Nothing was there to remove, so nothing changed for this hook. Restoring anyway would
+    // overwrite a value the caller had just set with the initial one.
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: null } })
+    })
+
+    expect(applyValue).not.toHaveBeenCalled()
+  })
+
   test('removes its listener on unmount', () => {
     const { storage, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
@@ -188,5 +245,72 @@ describe('use-storage-handler', () => {
     unmount()
 
     expect(removeListener).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the record of a hook s own writes', () => {
+  test('keeps only the most recent entries when no echo ever arrives', () => {
+    const pendingOwnWrites = createOwnWriteRecord()
+    const written = Array.from({ length: 12 }, (_, index) => `entry-${index}`)
+
+    for (const entry of written) recordOwnWrite(pendingOwnWrites, entry)
+
+    // A backend that reports nothing back leaves every record unmatched, and without a ceiling
+    // this grows by one string per write for as long as the hook is mounted. The oldest go: an
+    // echo is still owed for the newest.
+    expect(pendingOwnWrites.current).toEqual(written.slice(-8))
+  })
+
+  test('stops suppressing a record the backend has already reported past', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+    const pendingOwnWrites = createOwnWriteRecord()
+    const firstEntry = JSON.stringify({ [itemKey]: 'first' })
+    const secondEntry = JSON.stringify({ [itemKey]: 'second' })
+
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+
+    recordOwnWrite(pendingOwnWrites, firstEntry)
+    recordOwnWrite(pendingOwnWrites, secondEntry)
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: secondEntry } })
+    })
+
+    expect(applyValue).not.toHaveBeenCalled()
+
+    // A backend reports in the order it applied, so the first write's echo is never coming. Its
+    // record has to go with the second one's, or these bytes stay suppressed for good and a real
+    // write carrying them is dropped.
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: firstEntry } })
+    })
+
+    expect(applyValue).toHaveBeenCalledWith('first')
+  })
+
+  test('suppresses one echo for each record holding the same entry', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+    const pendingOwnWrites = createOwnWriteRecord()
+    const entry = JSON.stringify({ [itemKey]: 'unchanged' })
+
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+
+    // Two writes that happen to store the same bytes are owed two echoes. Matching the last
+    // record rather than the first drops both on the first echo, and the second is then read as
+    // somebody else's write.
+    recordOwnWrite(pendingOwnWrites, entry)
+    recordOwnWrite(pendingOwnWrites, entry)
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: entry } })
+    })
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: entry } })
+    })
+
+    expect(applyValue).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -7,7 +7,7 @@ const storageKey = 'persisted_state_hook:test'
 const itemKey = 'foo'
 
 // Stable across renders, as the ref the hooks pass in is.
-const createOwnWriteRecord = (): React.RefObject<string | null> => ({ current: null })
+const createOwnWriteRecord = (): React.RefObject<string[]> => ({ current: [] })
 
 function createSpyStorage() {
   const listeners = new Set<StorageChangeListener>()
@@ -40,11 +40,11 @@ describe('use-storage-handler', () => {
   test('keeps one subscription when initialValue is a new object on every render', () => {
     const { storage, addListener, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrite = createOwnWriteRecord()
+    const pendingOwnWrites = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ initialValue }) =>
-        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrite),
+        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
       { initialProps: { initialValue: { count: 0 } } },
     )
 
@@ -58,11 +58,11 @@ describe('use-storage-handler', () => {
   test('restores the initialValue of the latest render when the entry is removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrite = createOwnWriteRecord()
+    const pendingOwnWrites = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ initialValue }) =>
-        useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrite),
+        useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
       { initialProps: { initialValue: 'first' } },
     )
 
@@ -81,10 +81,10 @@ describe('use-storage-handler', () => {
   test('does not restore a function initialValue the removed entry already held', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrite = createOwnWriteRecord()
+    const pendingOwnWrites = createOwnWriteRecord()
 
     renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial', pendingOwnWrite),
+      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial', pendingOwnWrites),
     )
 
     act(() => {
@@ -99,10 +99,10 @@ describe('use-storage-handler', () => {
   test('applies a stored null instead of reading it as no value', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrite = createOwnWriteRecord()
+    const pendingOwnWrites = createOwnWriteRecord()
 
     renderHook(() =>
-      useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite),
+      useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
     )
 
     act(() => {
@@ -129,9 +129,9 @@ describe('use-storage-handler', () => {
     test('reports an entry that will not parse', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrite = createOwnWriteRecord()
+      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: 'not json' } })
@@ -144,9 +144,9 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that is a bare JSON primitive', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrite = createOwnWriteRecord()
+      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
 
       // A number parses, so this is not a broken entry: it is a foreign one, as
       // routine as an entry carrying only other keys. `in` throws on it, and the
@@ -163,9 +163,9 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that simply does not carry the key', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrite = createOwnWriteRecord()
+      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: JSON.stringify({ other: 'value' }) } })
@@ -179,10 +179,10 @@ describe('use-storage-handler', () => {
   test('removes its listener on unmount', () => {
     const { storage, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrite = createOwnWriteRecord()
+    const pendingOwnWrites = createOwnWriteRecord()
 
     const { unmount } = renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite),
+      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
     )
 
     unmount()

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -11,6 +11,24 @@ same tab. `esm/` therefore contains hand-written wrappers that re-export `lib/`,
 For the same reason the package must **not** gain `"type": "module"`, `sideEffects: false`, or a real
 dual build, and must keep `main` and `types` for resolvers that never read `exports`.
 
+## Why the wrappers are committed while `lib/` is not
+
+They look like build output and are not: nothing in this repository generates them. `lib/` is the
+build output, and it is correctly absent from git. `esm/` and `storages/` are sources that happen to
+be small.
+
+Generating them instead was measured rather than argued: the generator came to 101 lines against 87
+lines of wrapper, because the export names cannot be read statically out of the CommonJS build and
+have to be collected at runtime, which drags in the same global stubs the smoke test needs. It would
+also drop the comments that explain the constraint — the part worth keeping.
+
+The obvious objection is drift: add an adapter, forget its wrapper. That fails loudly. `publint` and
+`attw` name the missing file, `check:smoke` catches a wrapper whose shape no longer matches the
+build, and `check:types` catches a declaration re-exporting a name that is gone.
+
+Reaching for a dual-package builder — tshy, pkgroll, unbuild, tsdown — is the one move to avoid. All
+of them emit two compiled copies, which is the second registry this whole layer exists to prevent.
+
 ## What resolves to what
 
 ```mermaid

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -77,7 +77,9 @@ reported without an `oldValue` is ignored.
   adapters do this.
 - **One entry per factory.** Each `createPersistedState(name, storage)` factory reads and writes a
   single storage key, `persisted_state_hook:<name>`, containing a JSON object with one property per
-  hook key.
+  hook key. A write replaces all of it, so an entry the library cannot read — one that will not
+  parse, or that is not a JSON object — is left untouched instead: the write is reported and
+  skipped, so a foreign entry under the same key is never overwritten.
 - **Detection reads, and never writes.** The default export tells `Storage` and `AsyncStorage` apart
   from the shape of your methods first: a `get` declared `async` settles it without any call. Only
   when that does not hold does it call `get('')` once, as a method of your storage, and check whether

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -77,11 +77,17 @@ reported without an `oldValue` is ignored.
   adapters do this.
 - **One entry per factory.** Each `createPersistedState(name, storage)` factory reads and writes a
   single storage key, `persisted_state_hook:<name>`, containing a JSON object with one property per
-  hook key. A write replaces all of it, so on an asynchronous storage the library takes one write on
-  that key at a time: your `set` is never called for an entry merged from a snapshot another write
-  has since replaced. An entry the library cannot read — one that will not parse, or that is not a
-  JSON object — is left untouched instead: the write is reported and skipped, so a foreign entry
-  under the same key is never overwritten.
+  hook key. A write replaces all of it, so on an asynchronous storage the library takes one change
+  to that key at a time — writes and `clear` alike: your `set` is never called for an entry merged
+  from a snapshot another write has since replaced, and a removal is never undone by a write that
+  was already queued behind it. An entry the library cannot read — a string that will not parse, or
+  one that parses to something other than a JSON object — is left untouched instead: the write is
+  reported and skipped.
+- **The refusal reaches only as far as `get` reports.** An adapter that narrows a value to absent
+  hides it from that check, and the next write replaces it. This is what the bundled extension
+  adapters do with the non-string values their backend allows, so a foreign object under a
+  `persisted_state_hook:` key in extension storage is overwritten rather than preserved. An adapter
+  that wants a foreign value protected has to return it from `get` as the string it is.
 - **Detection reads, and never writes.** The default export tells `Storage` and `AsyncStorage` apart
   from the shape of your methods first: a `get` declared `async` settles it without any call. Only
   when that does not hold does it call `get('')` once, as a method of your storage, and check whether

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -77,9 +77,11 @@ reported without an `oldValue` is ignored.
   adapters do this.
 - **One entry per factory.** Each `createPersistedState(name, storage)` factory reads and writes a
   single storage key, `persisted_state_hook:<name>`, containing a JSON object with one property per
-  hook key. A write replaces all of it, so an entry the library cannot read — one that will not
-  parse, or that is not a JSON object — is left untouched instead: the write is reported and
-  skipped, so a foreign entry under the same key is never overwritten.
+  hook key. A write replaces all of it, so on an asynchronous storage the library takes one write on
+  that key at a time: your `set` is never called for an entry merged from a snapshot another write
+  has since replaced. An entry the library cannot read — one that will not parse, or that is not a
+  JSON object — is left untouched instead: the write is reported and skipped, so a foreign entry
+  under the same key is never overwritten.
 - **Detection reads, and never writes.** The default export tells `Storage` and `AsyncStorage` apart
   from the shape of your methods first: a `get` declared `async` settles it without any call. Only
   when that does not hold does it call `get('')` once, as a method of your storage, and check whether

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -15,10 +15,6 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
 ): [PersistedState, () => Promise<void>] {
   const safeStorageKey = `persisted_state_hook:${storageKey}`
 
-  const clear = (): Promise<void> => {
-    return storage.remove(safeStorageKey)
-  }
-
   // Every hook this factory makes lives in one entry, and storing a value means
   // reading that entry, merging one key into it and writing all of it back, with
   // a suspension point on either side of the merge. Left to overlap, a second
@@ -27,6 +23,18 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
   // screen, and nothing reports the disagreement. It is the entry, not the hook,
   // that has to be taken one at a time, so the chain belongs to the factory.
   let entryWrites: Promise<unknown> = Promise.resolve()
+
+  const clear = (): Promise<void> => {
+    // Removing the entry changes it as much as storing does, so it takes its turn
+    // in the same chain. Outside it, a write already queued lands after the
+    // removal and brings back what was cleared - and "clear this data" is the one
+    // request that cannot be allowed to half happen.
+    const removal = entryWrites.then(() => storage.remove(safeStorageKey))
+
+    entryWrites = removal.catch(() => undefined)
+
+    return removal
+  }
 
   const commitEntry = <T>(key: string, newValue: T, pendingOwnWrites: React.RefObject<string[]>): Promise<void> => {
     const write = entryWrites.then(async () => {

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -49,7 +49,17 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
         applyValue(newValue)
 
         const persistedItem = await storage.get(safeStorageKey)
-        const newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
+        let newItem: string
+
+        try {
+          newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
+        } catch {
+          // Refused, and reported where it was refused. A write replaces the whole
+          // entry, so an entry that cannot be read is one no write can be built on
+          // without dropping every other hook's key; skipping leaves the bytes for
+          // a repair to reach. The caller keeps what it set, unpersisted.
+          return
+        }
 
         // Recorded before the write, because the backend may report it before the
         // promise settles.

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import useStorageHandler from './utils/use-storage-handler'
+import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -17,6 +17,45 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
 
   const clear = (): Promise<void> => {
     return storage.remove(safeStorageKey)
+  }
+
+  // Every hook this factory makes lives in one entry, and storing a value means
+  // reading that entry, merging one key into it and writing all of it back, with
+  // a suspension point on either side of the merge. Left to overlap, a second
+  // writer merges into a snapshot taken before the first one landed and stores
+  // it: the first writer's key is gone from storage while its value is still on
+  // screen, and nothing reports the disagreement. It is the entry, not the hook,
+  // that has to be taken one at a time, so the chain belongs to the factory.
+  let entryWrites: Promise<unknown> = Promise.resolve()
+
+  const commitEntry = <T>(key: string, newValue: T, pendingOwnWrites: React.RefObject<string[]>): Promise<void> => {
+    const write = entryWrites.then(async () => {
+      const persistedItem = await storage.get(safeStorageKey)
+      let newItem: string
+
+      try {
+        newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
+      } catch {
+        // Refused, and reported where it was refused. A write replaces the whole
+        // entry, so an entry that cannot be read is one no write can be built on
+        // without dropping every other hook's key; skipping leaves the bytes for
+        // a repair to reach. The caller keeps what it set, unpersisted.
+        return
+      }
+
+      // Recorded before the write, because the backend may report it before the
+      // promise settles.
+      recordOwnWrite(pendingOwnWrites, newItem)
+
+      await storage.set({ [safeStorageKey]: newItem })
+    })
+
+    // The chain has to outlive a failed write, or one backend rejection stops
+    // every later write on this entry. The rejection itself is not swallowed: it
+    // stays on the promise handed back to the caller that asked for the write.
+    entryWrites = write.catch(() => undefined)
+
+    return write
   }
 
   const usePersistedState = <T>(key: string, initialValue: T | (() => T)): UsePersistedState<T> => {
@@ -39,33 +78,18 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
       setState(value)
     }, [])
 
-    // The exact entry this hook last wrote and has not yet seen reported back.
-    const pendingOwnWrite = useRef<string | null>(null)
+    // The entries this hook has written and not yet seen reported back.
+    const pendingOwnWrites = useRef<string[]>([])
 
     const setPersistedState = useCallback(
       async (newState: React.SetStateAction<T>): Promise<void> => {
         const newValue = getNewValue<T>(newState, latestValue.current)
 
+        // Applied before the write is even queued: the caller sees its value at
+        // once, and only the trip to storage waits its turn.
         applyValue(newValue)
 
-        const persistedItem = await storage.get(safeStorageKey)
-        let newItem: string
-
-        try {
-          newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
-        } catch {
-          // Refused, and reported where it was refused. A write replaces the whole
-          // entry, so an entry that cannot be read is one no write can be built on
-          // without dropping every other hook's key; skipping leaves the bytes for
-          // a repair to reach. The caller keeps what it set, unpersisted.
-          return
-        }
-
-        // Recorded before the write, because the backend may report it before the
-        // promise settles.
-        pendingOwnWrite.current = newItem
-
-        await storage.set({ [safeStorageKey]: newItem })
+        await commitEntry<T>(key, newValue, pendingOwnWrites)
       },
       [key, applyValue],
     )
@@ -80,7 +104,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
     // between the read and the subscription in which a write belongs to neither
     // and is lost. Reading last covers everything written before the subscription
     // began, and the listener covers everything after.
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrite)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
 
     useEffect(() => {
       // Two separate questions, and one cell cannot hold both: whether this load

--- a/src/create-persisted-state.ts
+++ b/src/create-persisted-state.ts
@@ -58,7 +58,17 @@ export default function createPersistedState(storageKey: string, storage: Storag
         applyValue(newValue)
 
         const persistedItem = storage.get(safeStorageKey)[safeStorageKey]
-        const newItem = getNewItem<T>(key, persistedItem, newValue)
+        let newItem: string
+
+        try {
+          newItem = getNewItem<T>(key, persistedItem, newValue)
+        } catch {
+          // Refused, and reported where it was refused. A write replaces the whole
+          // entry, so an entry that cannot be read is one no write can be built on
+          // without dropping every other hook's key; skipping leaves the bytes for
+          // a repair to reach. The caller keeps what it set, unpersisted.
+          return
+        }
 
         pendingOwnWrite.current = newItem
 

--- a/src/create-persisted-state.ts
+++ b/src/create-persisted-state.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react'
 import type { Storage } from './@types/storage'
 import type { PersistedState, UsePersistedState } from './@types/hook'
 
-import useStorageHandler from './utils/use-storage-handler'
+import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -48,8 +48,8 @@ export default function createPersistedState(storageKey: string, storage: Storag
       applyValue(readPersisted(key, initialValue))
     }
 
-    // The exact entry this hook last wrote and has not yet seen reported back.
-    const pendingOwnWrite = useRef<string | null>(null)
+    // The entries this hook has written and not yet seen reported back.
+    const pendingOwnWrites = useRef<string[]>([])
 
     const setPersistedState = useCallback(
       (newState: React.SetStateAction<T>): void => {
@@ -70,14 +70,14 @@ export default function createPersistedState(storageKey: string, storage: Storag
           return
         }
 
-        pendingOwnWrite.current = newItem
+        recordOwnWrite(pendingOwnWrites, newItem)
 
         storage.set({ [safeStorageKey]: newItem })
       },
       [key, applyValue],
     )
 
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrite)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
 
     return [state, setPersistedState]
   }

--- a/src/utils/get-new-item.ts
+++ b/src/utils/get-new-item.ts
@@ -1,16 +1,39 @@
-export default function <T>(key: string, persistedItem: string, newValue: T): string {
-  let persist: { [x: string]: unknown }
+import { isObject } from '@plq/is'
+
+/**
+ * Merges `newValue` under `key` into the serialized entry a factory shares between all of its
+ * hooks, and returns the entry to store.
+ *
+ * Reports and throws when the entry cannot be merged into, rather than answering with one built
+ * from nothing. What this returns is written over the whole entry, so an unreadable entry is the
+ * one case with nothing safe to return: every other hook's key would be replaced with nothing,
+ * and the bytes a repair still needs would go with them.
+ *
+ * @throws {SyntaxError} when the entry is not valid JSON.
+ * @throws {TypeError} when the entry is valid JSON but not an object of keys.
+ */
+export default function getNewItem<T>(key: string, persistedItem: string, newValue: T): string {
+  let persist: unknown
 
   try {
     persist = persistedItem ? JSON.parse(persistedItem) : {}
   } catch (err) {
-    console.error(err)
-    persist = {}
+    console.error("use-persisted-state: Can't write value to storage", err)
+
+    throw err
   }
 
-  return JSON.stringify(
-    Object.assign(persist, {
-      [key]: newValue,
-    }),
-  )
+  if (!isObject(persist)) {
+    // A shared backend can leave any JSON under the key, and neither a primitive nor an array
+    // survives being merged into: `JSON.stringify` unwraps the first back to itself and keeps the
+    // second an array, so the value being set disappears with the property added to it. A stored
+    // `null` did not even get that far - it threw out of `Object.assign` and into the caller.
+    const err = new TypeError('the stored entry is not an object of keys')
+
+    console.error("use-persisted-state: Can't write value to storage", err)
+
+    throw err
+  }
+
+  return JSON.stringify({ ...persist, [key]: newValue })
 }

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -103,12 +103,8 @@ export function recordOwnWrite(pendingOwnWrites: React.RefObject<string[]>, item
  * hook writing the same bytes is suppressed along with it, and nothing is lost:
  * it would have replaced a value with an equal one.
  */
-function consumeOwnWriteEcho(change: StorageChange, pendingOwnWrites: React.RefObject<string[]>): boolean {
-  // A removal carries no entry to match, and matching one against `undefined`
-  // would make an empty record answer for it.
-  if (typeof change.newValue !== 'string') return false
-
-  const matched = pendingOwnWrites.current.indexOf(change.newValue)
+function consumeOwnWriteEcho(entry: string, pendingOwnWrites: React.RefObject<string[]>): boolean {
+  const matched = pendingOwnWrites.current.indexOf(entry)
 
   if (matched === -1) return false
 
@@ -132,12 +128,15 @@ function createStorageHandler<T>(
     for (const [key, change] of Object.entries(changes)) {
       if (key !== storageKey) continue
 
-      if (consumeOwnWriteEcho(change, pendingOwnWrites)) continue
-
+      // Ahead of the echo check, which needs an entry to match and a removal has
+      // none. A removal is never one of this hook's own writes anyway: only the
+      // entries it stores are recorded.
       if (change.newValue === null || change.newValue === undefined) {
         applyRemoval<T>(change, itemKey, applyValue, latestInitialValue)
         continue
       }
+
+      if (consumeOwnWriteEcho(change.newValue, pendingOwnWrites)) continue
 
       const newValue = readStoredValue<T>(itemKey, change.newValue)
 

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -60,13 +60,37 @@ function applyRemoval<T>(
   applyValue(initialValue)
 }
 
+// A backend that reports nothing back leaves every record unmatched, so the list
+// needs a ceiling or it grows by one string per write for as long as the hook is
+// mounted. A bound, not a tuning: a backend that does report drains the list on
+// every echo, and one that reports late is what the list exists for.
+const MAX_PENDING_OWN_WRITES = 8
+
 /**
- * Reports whether this change is the write the hook itself just made, forgetting
- * the record when it is. A backend reports a write to every listener, the one
- * that made it included, and applying that echo is the storage-to-state re-sync
- * this hook was rebuilt without, arriving by another road: it decodes the entry
- * again and hands the caller an equal value with a new identity, plus a render
- * for a value it already holds.
+ * Remembers an entry the hook is about to write, so the change the backend
+ * reports for it can be told apart from someone else's write.
+ *
+ * Recorded before the write, because a backend may report it before the call
+ * settles. One slot was not enough: a backend free to report after its write
+ * settles - chrome and browser storage both are - lets the next write overwrite
+ * the record of a write still waiting to be reported, and that unsuppressed echo
+ * then puts the earlier value back over the later one.
+ */
+export function recordOwnWrite(pendingOwnWrites: React.RefObject<string[]>, item: string): void {
+  const pending = pendingOwnWrites.current
+
+  if (pending.length >= MAX_PENDING_OWN_WRITES) pending.shift()
+
+  pending.push(item)
+}
+
+/**
+ * Reports whether this change is a write the hook itself made, forgetting the
+ * record when it is. A backend reports a write to every listener, the one that
+ * made it included, and applying that echo is the storage-to-state re-sync this
+ * hook was rebuilt without, arriving by another road: it decodes the entry again
+ * and hands the caller an equal value with a new identity, plus a render for a
+ * value it already holds.
  *
  * The price, accepted knowingly: for a value JSON cannot carry, the writer keeps
  * what it set - NaN - while every other component on the key decodes the null
@@ -79,10 +103,19 @@ function applyRemoval<T>(
  * hook writing the same bytes is suppressed along with it, and nothing is lost:
  * it would have replaced a value with an equal one.
  */
-function consumeOwnWriteEcho(change: StorageChange, pendingOwnWrite: React.RefObject<string | null>): boolean {
-  if (pendingOwnWrite.current === null || change.newValue !== pendingOwnWrite.current) return false
+function consumeOwnWriteEcho(change: StorageChange, pendingOwnWrites: React.RefObject<string[]>): boolean {
+  // A removal carries no entry to match, and matching one against `undefined`
+  // would make an empty record answer for it.
+  if (typeof change.newValue !== 'string') return false
 
-  pendingOwnWrite.current = null
+  const matched = pendingOwnWrites.current.indexOf(change.newValue)
+
+  if (matched === -1) return false
+
+  // Everything recorded before the reported entry goes with it: a backend applies
+  // writes in the order it took them and reports them in that order too, so a
+  // record still unmatched by now has no echo left to wait for.
+  pendingOwnWrites.current.splice(0, matched + 1)
 
   return true
 }
@@ -93,13 +126,13 @@ function createStorageHandler<T>(
   storageKey: string,
   applyValue: (value: T) => void,
   latestInitialValue: React.RefObject<T | (() => T)>,
-  pendingOwnWrite: React.RefObject<string | null>,
+  pendingOwnWrites: React.RefObject<string[]>,
 ) {
   return (changes: { [key: string]: StorageChange }): void => {
     for (const [key, change] of Object.entries(changes)) {
       if (key !== storageKey) continue
 
-      if (consumeOwnWriteEcho(change, pendingOwnWrite)) continue
+      if (consumeOwnWriteEcho(change, pendingOwnWrites)) continue
 
       if (change.newValue === null || change.newValue === undefined) {
         applyRemoval<T>(change, itemKey, applyValue, latestInitialValue)
@@ -119,7 +152,7 @@ export default function useStorageHandler<T>(
   applyValue: (value: T) => void,
   storage: AsyncStorage | Storage,
   initialValue: T | (() => T),
-  pendingOwnWrite: React.RefObject<string | null>,
+  pendingOwnWrites: React.RefObject<string[]>,
 ): void {
   // A removal restores the initial value the hook holds now, the same one the
   // key-change path reads, so a caller whose default travels with its data gets
@@ -132,7 +165,7 @@ export default function useStorageHandler<T>(
   latestInitialValue.current = initialValue
 
   useEffect(() => {
-    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue, pendingOwnWrite)
+    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue, pendingOwnWrites)
 
     storage.onChanged.addListener(handleStorage)
 
@@ -141,5 +174,5 @@ export default function useStorageHandler<T>(
         storage.onChanged.removeListener(handleStorage)
       }
     }
-  }, [key, storage.onChanged, storageKey, applyValue, pendingOwnWrite])
+  }, [key, storage.onChanged, storageKey, applyValue, pendingOwnWrites])
 }


### PR DESCRIPTION
Three defects that lost data silently, and the tests that prove they are gone. All fixes — no new
API, no signature change. The published declarations are byte-for-byte identical to 1.4.0.

## What was broken

**A write onto an unreadable entry destroyed every other hook's data.** Each factory keeps one
storage entry holding a property per hook key. If that entry held something the library could not
parse — a truncated string, another library's value — the next write from any hook rebuilt the entry
from nothing and every sibling key was gone for good. Nothing surfaced it: the values stay in memory
until the page reloads.

The write is now reported and skipped. The bytes are left where they are.

**Two hooks writing at once lost one of the writes.** On an asynchronous storage the setter read the
entry, awaited, merged one key, and wrote it all back. Two hooks interleaved: the second read before
the first had written, so it put back a snapshot missing the first hook's key. Screen and storage
disagreed with nothing to report it. Writes on one entry now run one at a time, chained on the
factory, because it is the entry that cannot take two at once.

**`clear()` could be undone after it resolved.** A write already in flight landed after the removal
and brought erased data back. `clear()` now takes its place in the same chain.

A parse failure also used to reach the consumer as a `TypeError` out of an event handler; an entry
holding `null` was enough.

## What a consumer will notice

Writes to one factory's entry no longer overlap, so a write waits for those queued ahead of it. For a
toggle or a form this is not observable. For a setter driven by every keystroke, storage will trail
the screen — the writes all arrive, later. That is the cost of them no longer eating each other.

While an entry is unreadable no write to it succeeds until `clear()`. Previously such a write
succeeded by destroying the rest of the entry.

## Tests

146 → 155. Every new test was proven to fail against the defect it guards before it passed.

Two independent reviews ran against the first draft: a correctness review that re-ran the gates and
diffed the built declarations against `main`, and a mutation audit that broke the code 51 ways to see
which tests noticed. Between them they found nine real coverage gaps and one false green — a test
named for suppressing write echoes stayed green when echo suppression was removed entirely, because
it asserted the final value rather than object identity. All are closed, each with the mutation that
red-lights it.

The audit also refuted a claim made in the first draft: `act` does not swallow synchronous throws.
The comment that rested on it has been corrected rather than deleted, since the test itself is
sensitive.

## Deliberately not in this change

- A rejected write still reaches nowhere when the caller does not await the setter. Pre-existing, and
  fixing it changes the setter's contract.
- Thirteen tests in `data-types.test.tsx` named `should persist …` assert nothing about storage and
  stay green with persistence removed entirely. Pre-existing, and its own cleanup.
- Past eight delayed echoes the suppression buffer drops the oldest and state can move backwards.
  1.4.0 has the same class of defect; the boundary is now under test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Serialized writes are now ordered to prevent concurrent updates from overwriting each other.
  * Invalid or unreadable stored data no longer replaces valid storage or disrupts subsequent updates.
  * Clear operations are processed safely alongside in-flight writes.
  * Multiple rapid updates and delayed storage notifications are handled correctly.
  * Stored `NaN` and `Infinity` values now read back as `null`.

* **Documentation**
  * Expanded guidance for invalid persisted data, storage adapters, asynchronous writes, and package distribution.
  * Added release notes describing numeric-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->