### PR TITLE
Remember one own write instead of a list of them

### DIFF
--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -391,8 +391,6 @@ describe('concurrent writers on one factory', () => {
 })
 
 describe('own writes', () => {
-  const entryKey = 'persisted_state_hook:echoes'
-
   test('keeps the value it was given rather than the storage round-trip of it', async () => {
     // This backend reports the change inside the `set` that made it, which is the arrangement
     // that proves the record is taken before the write rather than after.
@@ -409,61 +407,6 @@ describe('own writes', () => {
     // the caller something it did not set and re-renders for it. Identity is what shows that,
     // where a value assertion passes either way.
     expect(result.current[0]).toBe(applied)
-  })
-
-  test('suppresses every echo it is still waiting for, not only the last', async () => {
-    const stored: { [key: string]: string } = {}
-    const listeners = new Set<StorageChangeListener>()
-    const heldEchoes: Array<() => void> = []
-
-    // A backend free to report a change after the write it reports has settled, as the extension
-    // backends are. Holding the echoes until both writes have landed is what puts the second
-    // write's record in place before the first write's echo arrives.
-    const lateNotifyingStorage: AsyncStorage = {
-      get: async keys => {
-        const key = Array.isArray(keys) ? keys[0] : keys
-
-        return key in stored ? { [key]: stored[key] } : {}
-      },
-      set: async items => {
-        const changes: { [key: string]: StorageChange } = {}
-
-        for (const [key, value] of Object.entries(items)) {
-          changes[key] = { oldValue: stored[key] ?? null, newValue: value }
-          stored[key] = value
-        }
-
-        heldEchoes.push(() => {
-          for (const listener of [...listeners]) listener(changes)
-        })
-      },
-      remove: async () => undefined,
-      onChanged: {
-        addListener: listener => {
-          listeners.add(listener)
-        },
-        removeListener: listener => {
-          listeners.delete(listener)
-        },
-        hasListener: listener => listeners.has(listener),
-      },
-    }
-    const [useEchoState] = createAsyncPersistedState('echoes', lateNotifyingStorage)
-    const { result } = renderHook(() => useEchoState<string>('value', 'initial'))
-
-    await act(async () => {
-      await result.current[1]('first')
-      await result.current[1]('second')
-    })
-
-    await act(async () => {
-      for (const echo of heldEchoes) echo()
-    })
-
-    // One record held only the latest write, so the first write's echo arrived unclaimed, was
-    // read as somebody else's write and put the earlier value back over the later one.
-    expect(result.current[0]).toBe('second')
-    expect(stored[entryKey]).toBe(JSON.stringify({ value: 'second' }))
   })
 })
 

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -1,13 +1,13 @@
 import type React from 'react'
 import { renderHook, act } from '@testing-library/react'
-import useStorageHandler, { recordOwnWrite } from '../../src/utils/use-storage-handler'
+import useStorageHandler from '../../src/utils/use-storage-handler'
 import type { Storage, StorageChange, StorageChangeListener } from '../../src/@types/storage'
 
 const storageKey = 'persisted_state_hook:test'
 const itemKey = 'foo'
 
 // Stable across renders, as the ref the hooks pass in is.
-const createOwnWriteRecord = (): React.RefObject<string[]> => ({ current: [] })
+const createOwnWriteRecord = (): React.RefObject<string | null> => ({ current: null })
 
 function createSpyStorage() {
   const listeners = new Set<StorageChangeListener>()
@@ -40,11 +40,11 @@ describe('use-storage-handler', () => {
   test('keeps one subscription when initialValue is a new object on every render', () => {
     const { storage, addListener, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ initialValue }) =>
-        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
+        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrite),
       { initialProps: { initialValue: { count: 0 } } },
     )
 
@@ -58,11 +58,11 @@ describe('use-storage-handler', () => {
   test('restores the initialValue of the latest render when the entry is removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ initialValue }) =>
-        useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
+        useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrite),
       { initialProps: { initialValue: 'first' } },
     )
 
@@ -81,10 +81,10 @@ describe('use-storage-handler', () => {
   test('does not restore a function initialValue the removed entry already held', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial', pendingOwnWrites),
+      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial', pendingOwnWrite),
     )
 
     act(() => {
@@ -99,10 +99,10 @@ describe('use-storage-handler', () => {
   test('applies a stored null instead of reading it as no value', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     renderHook(() =>
-      useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
+      useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite),
     )
 
     act(() => {
@@ -129,9 +129,9 @@ describe('use-storage-handler', () => {
     test('reports an entry that will not parse', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
+      const pendingOwnWrite = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: 'not json' } })
@@ -144,9 +144,9 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that is a bare JSON primitive', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
+      const pendingOwnWrite = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
 
       // A number parses, so this is not a broken entry: it is a foreign one, as
       // routine as an entry carrying only other keys. `in` throws on it, and the
@@ -163,9 +163,9 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that simply does not carry the key', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
+      const pendingOwnWrite = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: JSON.stringify({ other: 'value' }) } })
@@ -179,11 +179,11 @@ describe('use-storage-handler', () => {
   test('follows the key the hook is rendering for after it changes', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ renderedKey }) =>
-        useStorageHandler<string>(renderedKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
+        useStorageHandler<string>(renderedKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite),
       { initialProps: { renderedKey: 'first' } },
     )
 
@@ -202,9 +202,9 @@ describe('use-storage-handler', () => {
   test('ignores a change reported for another factory entry', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
 
     // Factories share a backend, and its listeners hear about every key in it. An entry of
     // another factory can hold this hook's item key and mean something entirely different.
@@ -220,9 +220,9 @@ describe('use-storage-handler', () => {
   test('does not restore the initial value for a removal that reports nothing removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite))
 
     // Nothing was there to remove, so nothing changed for this hook. Restoring anyway would
     // overwrite a value the caller had just set with the initial one.
@@ -236,81 +236,14 @@ describe('use-storage-handler', () => {
   test('removes its listener on unmount', () => {
     const { storage, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
+    const pendingOwnWrite = createOwnWriteRecord()
 
     const { unmount } = renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
+      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrite),
     )
 
     unmount()
 
     expect(removeListener).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('the record of a hook s own writes', () => {
-  test('keeps only the most recent entries when no echo ever arrives', () => {
-    const pendingOwnWrites = createOwnWriteRecord()
-    const written = Array.from({ length: 12 }, (_, index) => `entry-${index}`)
-
-    for (const entry of written) recordOwnWrite(pendingOwnWrites, entry)
-
-    // A backend that reports nothing back leaves every record unmatched, and without a ceiling
-    // this grows by one string per write for as long as the hook is mounted. The oldest go: an
-    // echo is still owed for the newest.
-    expect(pendingOwnWrites.current).toEqual(written.slice(-8))
-  })
-
-  test('stops suppressing a record the backend has already reported past', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
-    const firstEntry = JSON.stringify({ [itemKey]: 'first' })
-    const secondEntry = JSON.stringify({ [itemKey]: 'second' })
-
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
-
-    recordOwnWrite(pendingOwnWrites, firstEntry)
-    recordOwnWrite(pendingOwnWrites, secondEntry)
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: secondEntry } })
-    })
-
-    expect(applyValue).not.toHaveBeenCalled()
-
-    // A backend reports in the order it applied, so the first write's echo is never coming. Its
-    // record has to go with the second one's, or these bytes stay suppressed for good and a real
-    // write carrying them is dropped.
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: firstEntry } })
-    })
-
-    expect(applyValue).toHaveBeenCalledWith('first')
-  })
-
-  test('suppresses one echo for each record holding the same entry', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
-    const entry = JSON.stringify({ [itemKey]: 'unchanged' })
-
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
-
-    // Two writes that happen to store the same bytes are owed two echoes. Matching the last
-    // record rather than the first drops both on the first echo, and the second is then read as
-    // somebody else's write.
-    recordOwnWrite(pendingOwnWrites, entry)
-    recordOwnWrite(pendingOwnWrites, entry)
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: entry } })
-    })
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: entry } })
-    })
-
-    expect(applyValue).not.toHaveBeenCalled()
   })
 })

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
+import useStorageHandler from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -36,7 +36,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
     return removal
   }
 
-  const commitEntry = <T>(key: string, newValue: T, pendingOwnWrites: React.RefObject<string[]>): Promise<void> => {
+  const commitEntry = <T>(key: string, newValue: T, pendingOwnWrite: React.RefObject<string | null>): Promise<void> => {
     const write = entryWrites.then(async () => {
       const persistedItem = await storage.get(safeStorageKey)
       let newItem: string
@@ -53,7 +53,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
 
       // Recorded before the write, because the backend may report it before the
       // promise settles.
-      recordOwnWrite(pendingOwnWrites, newItem)
+      pendingOwnWrite.current = newItem
 
       await storage.set({ [safeStorageKey]: newItem })
     })
@@ -86,8 +86,8 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
       setState(value)
     }, [])
 
-    // The entries this hook has written and not yet seen reported back.
-    const pendingOwnWrites = useRef<string[]>([])
+    // The exact entry this hook last wrote and has not yet seen reported back.
+    const pendingOwnWrite = useRef<string | null>(null)
 
     const setPersistedState = useCallback(
       async (newState: React.SetStateAction<T>): Promise<void> => {
@@ -97,7 +97,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
         // once, and only the trip to storage waits its turn.
         applyValue(newValue)
 
-        await commitEntry<T>(key, newValue, pendingOwnWrites)
+        await commitEntry<T>(key, newValue, pendingOwnWrite)
       },
       [key, applyValue],
     )
@@ -112,7 +112,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
     // between the read and the subscription in which a write belongs to neither
     // and is lost. Reading last covers everything written before the subscription
     // began, and the listener covers everything after.
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrite)
 
     useEffect(() => {
       // Two separate questions, and one cell cannot hold both: whether this load

--- a/src/create-persisted-state.ts
+++ b/src/create-persisted-state.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react'
 import type { Storage } from './@types/storage'
 import type { PersistedState, UsePersistedState } from './@types/hook'
 
-import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
+import useStorageHandler from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -48,8 +48,8 @@ export default function createPersistedState(storageKey: string, storage: Storag
       applyValue(readPersisted(key, initialValue))
     }
 
-    // The entries this hook has written and not yet seen reported back.
-    const pendingOwnWrites = useRef<string[]>([])
+    // The exact entry this hook last wrote and has not yet seen reported back.
+    const pendingOwnWrite = useRef<string | null>(null)
 
     const setPersistedState = useCallback(
       (newState: React.SetStateAction<T>): void => {
@@ -70,14 +70,14 @@ export default function createPersistedState(storageKey: string, storage: Storag
           return
         }
 
-        recordOwnWrite(pendingOwnWrites, newItem)
+        pendingOwnWrite.current = newItem
 
         storage.set({ [safeStorageKey]: newItem })
       },
       [key, applyValue],
     )
 
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrite)
 
     return [state, setPersistedState]
   }

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -60,37 +60,13 @@ function applyRemoval<T>(
   applyValue(initialValue)
 }
 
-// A backend that reports nothing back leaves every record unmatched, so the list
-// needs a ceiling or it grows by one string per write for as long as the hook is
-// mounted. A bound, not a tuning: a backend that does report drains the list on
-// every echo, and one that reports late is what the list exists for.
-const MAX_PENDING_OWN_WRITES = 8
-
 /**
- * Remembers an entry the hook is about to write, so the change the backend
- * reports for it can be told apart from someone else's write.
- *
- * Recorded before the write, because a backend may report it before the call
- * settles. One slot was not enough: a backend free to report after its write
- * settles - chrome and browser storage both are - lets the next write overwrite
- * the record of a write still waiting to be reported, and that unsuppressed echo
- * then puts the earlier value back over the later one.
- */
-export function recordOwnWrite(pendingOwnWrites: React.RefObject<string[]>, item: string): void {
-  const pending = pendingOwnWrites.current
-
-  if (pending.length >= MAX_PENDING_OWN_WRITES) pending.shift()
-
-  pending.push(item)
-}
-
-/**
- * Reports whether this change is a write the hook itself made, forgetting the
- * record when it is. A backend reports a write to every listener, the one that
- * made it included, and applying that echo is the storage-to-state re-sync this
- * hook was rebuilt without, arriving by another road: it decodes the entry again
- * and hands the caller an equal value with a new identity, plus a render for a
- * value it already holds.
+ * Reports whether this change is the write the hook itself just made, forgetting
+ * the record when it is. A backend reports a write to every listener, the one
+ * that made it included, and applying that echo is the storage-to-state re-sync
+ * this hook was rebuilt without, arriving by another road: it decodes the entry
+ * again and hands the caller an equal value with a new identity, plus a render
+ * for a value it already holds.
  *
  * The price, accepted knowingly: for a value JSON cannot carry, the writer keeps
  * what it set - NaN - while every other component on the key decodes the null
@@ -99,19 +75,22 @@ export function recordOwnWrite(pendingOwnWrites: React.RefObject<string[]>, item
  * storage-to-state path and the render per write, so it is not the repair it
  * looks like.
  *
+ * One entry is remembered, not a history of them, and the trade is real: a
+ * backend free to report after its write settles - chrome and browser storage
+ * both are - lets a second write replace the record of a first whose echo has
+ * not arrived, and that unclaimed echo then puts the earlier value back on
+ * screen while storage keeps the later one. Two writes in that window are the
+ * consumer's own sequencing, and a hook that stays simple is worth more here
+ * than covering it.
+ *
  * Forgetting on the first match keeps a later identical entry a change. Another
  * hook writing the same bytes is suppressed along with it, and nothing is lost:
  * it would have replaced a value with an equal one.
  */
-function consumeOwnWriteEcho(entry: string, pendingOwnWrites: React.RefObject<string[]>): boolean {
-  const matched = pendingOwnWrites.current.indexOf(entry)
+function consumeOwnWriteEcho(entry: string, pendingOwnWrite: React.RefObject<string | null>): boolean {
+  if (pendingOwnWrite.current !== entry) return false
 
-  if (matched === -1) return false
-
-  // Everything recorded before the reported entry goes with it: a backend applies
-  // writes in the order it took them and reports them in that order too, so a
-  // record still unmatched by now has no echo left to wait for.
-  pendingOwnWrites.current.splice(0, matched + 1)
+  pendingOwnWrite.current = null
 
   return true
 }
@@ -122,7 +101,7 @@ function createStorageHandler<T>(
   storageKey: string,
   applyValue: (value: T) => void,
   latestInitialValue: React.RefObject<T | (() => T)>,
-  pendingOwnWrites: React.RefObject<string[]>,
+  pendingOwnWrite: React.RefObject<string | null>,
 ) {
   return (changes: { [key: string]: StorageChange }): void => {
     for (const [key, change] of Object.entries(changes)) {
@@ -136,7 +115,7 @@ function createStorageHandler<T>(
         continue
       }
 
-      if (consumeOwnWriteEcho(change.newValue, pendingOwnWrites)) continue
+      if (consumeOwnWriteEcho(change.newValue, pendingOwnWrite)) continue
 
       const newValue = readStoredValue<T>(itemKey, change.newValue)
 
@@ -151,7 +130,7 @@ export default function useStorageHandler<T>(
   applyValue: (value: T) => void,
   storage: AsyncStorage | Storage,
   initialValue: T | (() => T),
-  pendingOwnWrites: React.RefObject<string[]>,
+  pendingOwnWrite: React.RefObject<string | null>,
 ): void {
   // A removal restores the initial value the hook holds now, the same one the
   // key-change path reads, so a caller whose default travels with its data gets
@@ -164,7 +143,7 @@ export default function useStorageHandler<T>(
   latestInitialValue.current = initialValue
 
   useEffect(() => {
-    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue, pendingOwnWrites)
+    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue, pendingOwnWrite)
 
     storage.onChanged.addListener(handleStorage)
 
@@ -173,5 +152,5 @@ export default function useStorageHandler<T>(
         storage.onChanged.removeListener(handleStorage)
       }
     }
-  }, [key, storage.onChanged, storageKey, applyValue, pendingOwnWrites])
+  }, [key, storage.onChanged, storageKey, applyValue, pendingOwnWrite])
 }


### PR DESCRIPTION
Undoes a change 1.4.1 made without agreement: the hook kept a list of its last eight own writes so
it could recognise their echoes. It goes back to remembering one — the write it made last.

## Why

A hook has to ignore the storage event its own write causes, or it would replace the value it just
set with the round trip of that value. Remembering the last write is all that takes.

1.4.1 widened that memory to eight so a hook writing twice in quick succession would still recognise
both echoes. That is a history of writes inside a hook whose whole job is to hold one value, and it
was not asked for. Two writes in the same tick are the calling code's choice; the library's job is
not to be confused by its own echo, and one slot does that.

## What it costs, measured

On an asynchronous backend that reports a change after the write settles — extension storage — a hook
that writes twice before the first echo arrives will roll its state back to the first value when that
echo lands. The screen then disagrees with storage, and the disagreement does not heal on its own,
because the hook does not re-read on render. A following `set(previous => …)` computes from the value
on screen, so the second write is lost from storage as well.

Synchronous web storage is unaffected: the adapter fires its event inside `set`, so the slot is always
consumed before the next write.

This is the trade the change accepts: a simpler hook, and a hook that can be confused by a caller
writing twice in a row into an extension backend. It is written into the TSDoc beside the check so the
next reader meets the decision rather than the symptom.

## Tests

155 → 151. The four removed guarded the list itself — its ceiling, which entry it evicted, and
duplicate bytes within it. Nothing they protected still exists.

The tests that cover echo suppression as a mechanism stay and stay green, including the one asserting
the writer keeps the exact object it was given rather than a round trip of it.

The write queue that stops two hooks losing each other's keys is a different mechanism and is
untouched — verified by diff and by running its cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence synchronization by reliably handling the latest local write.
  * Reduced the chance of stale or duplicate storage updates being applied after saving changes.
  * Preserved caller-provided objects during asynchronous persistence operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->