### PR TITLE
fix: apply all storage change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ tells a `null` you stored apart from a `null` that JSON produced.
   keeps `undefined` in memory, as `useState` would, and other components already mounted on that key
   see no change and keep the value they hold. After a remount or a reload the key is absent, so the
   initial value comes back.
-- **`NaN`, `Infinity`, `-Infinity`** — these are written as `null`. The component that set the value
-  keeps it until it remounts; every other component on that key reads back `null`, as does any
-  reader after a reload.
+- **`NaN`, `Infinity`, `-Infinity`** — these are written as `null`. A storage change reported by the
+  backend applies that `null` to every listening component, including the writer. Any reader after
+  a reload also reads back `null`.
 
 ## Contributing
 

--- a/__tests__/component-tree.test.tsx
+++ b/__tests__/component-tree.test.tsx
@@ -1,5 +1,5 @@
-import React, { Profiler, memo, useEffect, useState } from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React, { Profiler, memo, useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import createPersistedState from '../src'
 import storage from '../src/storages/local-storage'
@@ -23,91 +23,6 @@ describe('a tree holding the hook', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-  })
-
-  test('settles a write into a single commit of the whole tree', async () => {
-    let commits = 0
-    const Writer = () => {
-      const [count, setCount] = usePersistedState('commits', 0)
-
-      return (
-        <button type="button" data-testid="writer" onClick={() => setCount(previous => previous + 1)}>
-          {count}
-        </button>
-      )
-    }
-    const Reader = () => {
-      const [count] = usePersistedState('commits', 0)
-
-      return <span data-testid="reader">{count}</span>
-    }
-
-    render(
-      <Profiler
-        id="tree"
-        onRender={() => {
-          commits += 1
-        }}
-      >
-        <Writer />
-        <Reader />
-      </Profiler>,
-    )
-
-    commits = 0
-
-    fireEvent.click(screen.getByTestId('writer'))
-
-    // Waiting past the click is what gives the count below its meaning. A backend
-    // reporting the write to its listeners a tick later would still reach the
-    // reader, but in a second commit — and between the two the tree paints the
-    // writer's new value beside the reader's old one.
-    await waitFor(() => expect(screen.getByTestId('reader')).toHaveTextContent('1'))
-
-    expect(commits).toBe(1)
-  })
-
-  /**
-   * The commit count above cannot see this one. An echo of the hook's own write
-   * arrives while React is still batching the click, so applying it costs no
-   * extra commit — it swaps the value for an equal one decoded out of storage,
-   * and only its identity gives that away.
-   */
-  test('hands back the object it was given, leaving an effect keyed on it asleep', () => {
-    const seenByEffect: { count: number }[] = []
-    const applied = { count: 1 }
-
-    const Consumer = () => {
-      const [value, setValue] = usePersistedState<{ count: number }>('identity', { count: 0 })
-
-      useEffect(() => {
-        seenByEffect.push(value)
-      }, [value])
-
-      return (
-        <button type="button" data-testid="writer" onClick={() => setValue(applied)}>
-          {value.count}
-        </button>
-      )
-    }
-
-    render(<Consumer />)
-
-    fireEvent.click(screen.getByTestId('writer'))
-
-    expect(screen.getByTestId('writer')).toHaveTextContent('1')
-    // What the consumer holds is the object it set, not an equal one decoded back
-    // out of storage.
-    expect(seenByEffect[seenByEffect.length - 1]).toBe(applied)
-
-    const wakesAfterFirstWrite = seenByEffect.length
-
-    fireEvent.click(screen.getByTestId('writer'))
-
-    // Writing the same object again changes nothing a consumer could act on. A
-    // hook that took the storage round-trip would hand back a fresh parse each
-    // time, waking every effect and memo that holds the value on every write.
-    expect(seenByEffect).toHaveLength(wakesAfterFirstWrite)
   })
 
   test('leaves a memoized child alone when the setter is the prop it receives', () => {

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -390,12 +390,8 @@ describe('concurrent writers on one factory', () => {
   })
 })
 
-describe('own writes', () => {
-  const entryKey = 'persisted_state_hook:echoes'
-
-  test('keeps the value it was given rather than the storage round-trip of it', async () => {
-    // This backend reports the change inside the `set` that made it, which is the arrangement
-    // that proves the record is taken before the write rather than after.
+describe('storage round-trips', () => {
+  test('applies the storage event emitted by its own write', async () => {
     const { asyncStorage } = createFakeAsyncStorage()
     const [useOwnState] = createAsyncPersistedState('own', asyncStorage)
     const { result } = renderHook(() => useOwnState<{ count: number }>('own', { count: 0 }))
@@ -405,65 +401,8 @@ describe('own writes', () => {
       await result.current[1](applied)
     })
 
-    // Decoding the echo yields an equal object with a new identity, so an unsuppressed echo hands
-    // the caller something it did not set and re-renders for it. Identity is what shows that,
-    // where a value assertion passes either way.
-    expect(result.current[0]).toBe(applied)
-  })
-
-  test('suppresses every echo it is still waiting for, not only the last', async () => {
-    const stored: { [key: string]: string } = {}
-    const listeners = new Set<StorageChangeListener>()
-    const heldEchoes: Array<() => void> = []
-
-    // A backend free to report a change after the write it reports has settled, as the extension
-    // backends are. Holding the echoes until both writes have landed is what puts the second
-    // write's record in place before the first write's echo arrives.
-    const lateNotifyingStorage: AsyncStorage = {
-      get: async keys => {
-        const key = Array.isArray(keys) ? keys[0] : keys
-
-        return key in stored ? { [key]: stored[key] } : {}
-      },
-      set: async items => {
-        const changes: { [key: string]: StorageChange } = {}
-
-        for (const [key, value] of Object.entries(items)) {
-          changes[key] = { oldValue: stored[key] ?? null, newValue: value }
-          stored[key] = value
-        }
-
-        heldEchoes.push(() => {
-          for (const listener of [...listeners]) listener(changes)
-        })
-      },
-      remove: async () => undefined,
-      onChanged: {
-        addListener: listener => {
-          listeners.add(listener)
-        },
-        removeListener: listener => {
-          listeners.delete(listener)
-        },
-        hasListener: listener => listeners.has(listener),
-      },
-    }
-    const [useEchoState] = createAsyncPersistedState('echoes', lateNotifyingStorage)
-    const { result } = renderHook(() => useEchoState<string>('value', 'initial'))
-
-    await act(async () => {
-      await result.current[1]('first')
-      await result.current[1]('second')
-    })
-
-    await act(async () => {
-      for (const echo of heldEchoes) echo()
-    })
-
-    // One record held only the latest write, so the first write's echo arrived unclaimed, was
-    // read as somebody else's write and put the earlier value back over the later one.
-    expect(result.current[0]).toBe('second')
-    expect(stored[entryKey]).toBe(JSON.stringify({ value: 'second' }))
+    expect(result.current[0]).toEqual(applied)
+    expect(result.current[0]).not.toBe(applied)
   })
 })
 

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -183,7 +183,7 @@ describe('clearing', () => {
   })
 })
 
-describe('own writes', () => {
+describe('storage round-trips', () => {
   const entryKey = 'persisted_state_hook:echo'
   const [usePersistedState] = createPersistedState('echo', storage)
 
@@ -192,7 +192,7 @@ describe('own writes', () => {
     localStorage.clear()
   })
 
-  test('keeps the value it was given rather than the storage round-trip of it', () => {
+  test('applies the storage event emitted by its own write', () => {
     const { result } = renderHook(() => usePersistedState<{ count: number }>('own', { count: 0 }))
     const applied = { count: 1 }
 
@@ -200,10 +200,8 @@ describe('own writes', () => {
       result.current[1](applied)
     })
 
-    // The adapter reports the write back, and decoding it yields an equal object
-    // with a new identity, so the caller is handed something it did not set and
-    // re-renders for it.
-    expect(result.current[0]).toBe(applied)
+    expect(result.current[0]).toEqual(applied)
+    expect(result.current[0]).not.toBe(applied)
   })
 
   test('still applies a write made by another hook on the same key', () => {
@@ -217,14 +215,14 @@ describe('own writes', () => {
     expect(reader.current[0]).toBe('from the writer')
   })
 
-  test('consumes the suppression on the echo it was recorded for', () => {
+  test('applies a later event even when its entry matches an earlier write', () => {
     const { result } = renderHook(() => usePersistedState('sticky', 'initial'))
 
     act(() => {
       result.current[1]('first')
     })
 
-    const ownEntry = localStorage.__STORE__[entryKey]
+    const earlierEntry = localStorage.__STORE__[entryKey]
 
     act(() => {
       storage.set({ [entryKey]: JSON.stringify({ sticky: 'second' }) })
@@ -232,10 +230,8 @@ describe('own writes', () => {
 
     expect(result.current[0]).toBe('second')
 
-    // The same bytes arriving again are a genuine external write, not the echo
-    // the suppression was recorded for.
     act(() => {
-      storage.set({ [entryKey]: ownEntry })
+      storage.set({ [entryKey]: earlierEntry })
     })
 
     expect(result.current[0]).toBe('first')

--- a/__tests__/data-types.test.tsx
+++ b/__tests__/data-types.test.tsx
@@ -280,41 +280,18 @@ describe('Data Types Persistence', () => {
   })
 
   describe('Edge Cases', () => {
-    test('should handle NaN values', () => {
-      const { result } = renderHook(() => usePersistedState('nanKey', 0))
+    test.each([
+      ['NaN', 'nanKey', NaN],
+      ['Infinity', 'infinityKey', Infinity],
+      ['-Infinity', 'negInfinityKey', -Infinity],
+    ])('applies stored null after writing %s', (_label, key, value) => {
+      const { result } = renderHook(() => usePersistedState<number | null>(key, 0))
 
       act(() => {
-        result.current[1](NaN)
+        result.current[1](value)
       })
 
-      // Parity with useState within the session: the value handed to the setter is the value the
-      // component keeps. It does not outlive a reload — JSON has no NaN, `JSON.stringify` writes
-      // null, and nothing here promises otherwise; the case below pins what a later reader sees
-      // instead. The accepted cost is that until something remounts, another component on this
-      // key reads the stored null while this one still holds NaN — deliberate, not an oversight,
-      // and the alternative was a second copy of the re-sync the hook deleted. The Infinity cases
-      // follow the same rule.
-      expect(result.current[0]).toBeNaN()
-    })
-
-    test('should handle Infinity values', () => {
-      const { result } = renderHook(() => usePersistedState('infinityKey', 0))
-
-      act(() => {
-        result.current[1](Infinity)
-      })
-
-      expect(result.current[0]).toBe(Infinity)
-    })
-
-    test('should handle -Infinity values', () => {
-      const { result } = renderHook(() => usePersistedState('negInfinityKey', 0))
-
-      act(() => {
-        result.current[1](-Infinity)
-      })
-
-      expect(result.current[0]).toBe(-Infinity)
+      expect(result.current[0]).toBeNull()
     })
 
     test('should read back a NaN written by an earlier instance as null', () => {

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -1,13 +1,9 @@
-import type React from 'react'
 import { renderHook, act } from '@testing-library/react'
 import useStorageHandler from '../../src/utils/use-storage-handler'
 import type { Storage, StorageChange, StorageChangeListener } from '../../src/@types/storage'
 
 const storageKey = 'persisted_state_hook:test'
 const itemKey = 'foo'
-
-// Stable across renders, as the ref the hooks pass in is.
-const createOwnWriteRecord = (): React.RefObject<string[]> => ({ current: [] })
 
 function createSpyStorage() {
   const listeners = new Set<StorageChangeListener>()
@@ -40,11 +36,10 @@ describe('use-storage-handler', () => {
   test('keeps one subscription when initialValue is a new object on every render', () => {
     const { storage, addListener, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
     const { rerender } = renderHook(
       ({ initialValue }) =>
-        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
+        useStorageHandler<{ count: number }>(itemKey, storageKey, applyValue, storage, initialValue),
       { initialProps: { initialValue: { count: 0 } } },
     )
 
@@ -58,11 +53,9 @@ describe('use-storage-handler', () => {
   test('restores the initialValue of the latest render when the entry is removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
     const { rerender } = renderHook(
-      ({ initialValue }) =>
-        useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue, pendingOwnWrites),
+      ({ initialValue }) => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue),
       { initialProps: { initialValue: 'first' } },
     )
 
@@ -81,11 +74,8 @@ describe('use-storage-handler', () => {
   test('does not restore a function initialValue the removed entry already held', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
-    renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial', pendingOwnWrites),
-    )
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial'))
 
     act(() => {
       fire({ [storageKey]: { oldValue: JSON.stringify({ [itemKey]: 'initial' }), newValue: null } })
@@ -99,11 +89,8 @@ describe('use-storage-handler', () => {
   test('applies a stored null instead of reading it as no value', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
-    renderHook(() =>
-      useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
-    )
+    renderHook(() => useStorageHandler<string | null>(itemKey, storageKey, applyValue, storage, 'initial'))
 
     act(() => {
       fire({ [storageKey]: { oldValue: null, newValue: JSON.stringify({ [itemKey]: null }) } })
@@ -129,9 +116,8 @@ describe('use-storage-handler', () => {
     test('reports an entry that will not parse', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: 'not json' } })
@@ -144,9 +130,8 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that is a bare JSON primitive', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
       // A number parses, so this is not a broken entry: it is a foreign one, as
       // routine as an entry carrying only other keys. `in` throws on it, and the
@@ -163,9 +148,8 @@ describe('use-storage-handler', () => {
     test('says nothing about an entry that simply does not carry the key', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
-      const pendingOwnWrites = createOwnWriteRecord()
 
-      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: JSON.stringify({ other: 'value' }) } })
@@ -179,11 +163,9 @@ describe('use-storage-handler', () => {
   test('follows the key the hook is rendering for after it changes', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
     const { rerender } = renderHook(
-      ({ renderedKey }) =>
-        useStorageHandler<string>(renderedKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
+      ({ renderedKey }) => useStorageHandler<string>(renderedKey, storageKey, applyValue, storage, 'initial'),
       { initialProps: { renderedKey: 'first' } },
     )
 
@@ -202,9 +184,8 @@ describe('use-storage-handler', () => {
   test('ignores a change reported for another factory entry', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
     // Factories share a backend, and its listeners hear about every key in it. An entry of
     // another factory can hold this hook's item key and mean something entirely different.
@@ -220,9 +201,8 @@ describe('use-storage-handler', () => {
   test('does not restore the initial value for a removal that reports nothing removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
+    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
     // Nothing was there to remove, so nothing changed for this hook. Restoring anyway would
     // overwrite a value the caller had just set with the initial one.
@@ -236,11 +216,8 @@ describe('use-storage-handler', () => {
   test('removes its listener on unmount', () => {
     const { storage, removeListener } = createSpyStorage()
     const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
 
-    const { unmount } = renderHook(() =>
-      useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites),
-    )
+    const { unmount } = renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
     unmount()
 

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { renderHook, act } from '@testing-library/react'
-import useStorageHandler, { recordOwnWrite } from '../../src/utils/use-storage-handler'
+import useStorageHandler from '../../src/utils/use-storage-handler'
 import type { Storage, StorageChange, StorageChangeListener } from '../../src/@types/storage'
 
 const storageKey = 'persisted_state_hook:test'
@@ -245,72 +245,5 @@ describe('use-storage-handler', () => {
     unmount()
 
     expect(removeListener).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('the record of a hook s own writes', () => {
-  test('keeps only the most recent entries when no echo ever arrives', () => {
-    const pendingOwnWrites = createOwnWriteRecord()
-    const written = Array.from({ length: 12 }, (_, index) => `entry-${index}`)
-
-    for (const entry of written) recordOwnWrite(pendingOwnWrites, entry)
-
-    // A backend that reports nothing back leaves every record unmatched, and without a ceiling
-    // this grows by one string per write for as long as the hook is mounted. The oldest go: an
-    // echo is still owed for the newest.
-    expect(pendingOwnWrites.current).toEqual(written.slice(-8))
-  })
-
-  test('stops suppressing a record the backend has already reported past', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
-    const firstEntry = JSON.stringify({ [itemKey]: 'first' })
-    const secondEntry = JSON.stringify({ [itemKey]: 'second' })
-
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
-
-    recordOwnWrite(pendingOwnWrites, firstEntry)
-    recordOwnWrite(pendingOwnWrites, secondEntry)
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: secondEntry } })
-    })
-
-    expect(applyValue).not.toHaveBeenCalled()
-
-    // A backend reports in the order it applied, so the first write's echo is never coming. Its
-    // record has to go with the second one's, or these bytes stay suppressed for good and a real
-    // write carrying them is dropped.
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: firstEntry } })
-    })
-
-    expect(applyValue).toHaveBeenCalledWith('first')
-  })
-
-  test('suppresses one echo for each record holding the same entry', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
-    const pendingOwnWrites = createOwnWriteRecord()
-    const entry = JSON.stringify({ [itemKey]: 'unchanged' })
-
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial', pendingOwnWrites))
-
-    // Two writes that happen to store the same bytes are owed two echoes. Matching the last
-    // record rather than the first drops both on the first echo, and the second is then read as
-    // somebody else's write.
-    recordOwnWrite(pendingOwnWrites, entry)
-    recordOwnWrite(pendingOwnWrites, entry)
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: entry } })
-    })
-
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: entry } })
-    })
-
-    expect(applyValue).not.toHaveBeenCalled()
   })
 })

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
+import useStorageHandler from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -27,7 +27,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
     return removal
   }
 
-  const commitEntry = <T>(key: string, newValue: T, pendingOwnWrites: React.RefObject<string[]>): Promise<void> => {
+  const commitEntry = <T>(key: string, newValue: T): Promise<void> => {
     const write = entryWrites.then(async () => {
       const persistedItem = await storage.get(safeStorageKey)
       let newItem: string
@@ -38,8 +38,6 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
         // A write replaces the whole entry, so an unreadable one is skipped rather than rebuilt without other keys.
         return
       }
-
-      recordOwnWrite(pendingOwnWrites, newItem)
 
       await storage.set({ [safeStorageKey]: newItem })
     })
@@ -66,15 +64,13 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
       setState(value)
     }, [])
 
-    const pendingOwnWrites = useRef<string[]>([])
-
     const setPersistedState = useCallback(
       async (newState: React.SetStateAction<T>): Promise<void> => {
         const newValue = getNewValue<T>(newState, latestValue.current)
 
         applyValue(newValue)
 
-        await commitEntry<T>(key, newValue, pendingOwnWrites)
+        await commitEntry<T>(key, newValue)
       },
       [key, applyValue],
     )
@@ -83,7 +79,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
     const mountInitialValue = useRef(initialValue)
 
     // Subscribed before the load: effects run in declaration order, and reading first would lose writes in between.
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue)
 
     useEffect(() => {
       // Separate from `hasAppliedValue`: only this closure knows whether its own load is still current.

--- a/src/create-persisted-state.ts
+++ b/src/create-persisted-state.ts
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react'
 import type { Storage } from './@types/storage'
 import type { PersistedState, UsePersistedState } from './@types/hook'
 
-import useStorageHandler, { recordOwnWrite } from './utils/use-storage-handler'
+import useStorageHandler from './utils/use-storage-handler'
 import getNewValue from './utils/get-new-value'
 import getNewItem from './utils/get-new-item'
 import getPersistedValue from './utils/get-persisted-value'
@@ -40,8 +40,6 @@ export default function createPersistedState(storageKey: string, storage: Storag
       applyValue(readPersisted(key, initialValue))
     }
 
-    const pendingOwnWrites = useRef<string[]>([])
-
     const setPersistedState = useCallback(
       (newState: React.SetStateAction<T>): void => {
         const newValue = getNewValue<T>(newState, latestValue.current)
@@ -58,14 +56,12 @@ export default function createPersistedState(storageKey: string, storage: Storag
           return
         }
 
-        recordOwnWrite(pendingOwnWrites, newItem)
-
         storage.set({ [safeStorageKey]: newItem })
       },
       [key, applyValue],
     )
 
-    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue, pendingOwnWrites)
+    useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue)
 
     return [state, setPersistedState]
   }

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -42,49 +42,20 @@ function applyRemoval<T>(
   applyValue(initialValue)
 }
 
-// A list, not one slot: a write may still be awaiting its echo when the next one starts.
-// Capped, because a backend that never reports back leaves every record unmatched.
-const MAX_PENDING_OWN_WRITES = 8
-
-/** Records an entry before it is written, because a backend may report the change before the write settles. */
-export function recordOwnWrite(pendingOwnWrites: React.RefObject<string[]>, item: string): void {
-  const pending = pendingOwnWrites.current
-
-  if (pending.length >= MAX_PENDING_OWN_WRITES) pending.shift()
-
-  pending.push(item)
-}
-
-// Applying a hook's own echo would re-decode the entry and re-render for a value it already holds.
-function consumeOwnWriteEcho(entry: string, pendingOwnWrites: React.RefObject<string[]>): boolean {
-  const matched = pendingOwnWrites.current.indexOf(entry)
-
-  if (matched === -1) return false
-
-  // A backend reports writes in the order it took them, so a record still unmatched has no echo left.
-  pendingOwnWrites.current.splice(0, matched + 1)
-
-  return true
-}
-
 function createStorageHandler<T>(
   itemKey: string,
   storageKey: string,
   applyValue: (value: T) => void,
   latestInitialValue: React.RefObject<T | (() => T)>,
-  pendingOwnWrites: React.RefObject<string[]>,
 ) {
   return (changes: { [key: string]: StorageChange }): void => {
     for (const [key, change] of Object.entries(changes)) {
       if (key !== storageKey) continue
 
-      // Ahead of the echo check, which needs an entry to match and a removal has none.
       if (change.newValue === null || change.newValue === undefined) {
         applyRemoval<T>(change, itemKey, applyValue, latestInitialValue)
         continue
       }
-
-      if (consumeOwnWriteEcho(change.newValue, pendingOwnWrites)) continue
 
       const newValue = readStoredValue<T>(itemKey, change.newValue)
 
@@ -99,7 +70,6 @@ export default function useStorageHandler<T>(
   applyValue: (value: T) => void,
   storage: AsyncStorage | Storage,
   initialValue: T | (() => T),
-  pendingOwnWrites: React.RefObject<string[]>,
 ): void {
   // A ref, not a dependency: an inline initial value changes identity every render and would churn it.
   const latestInitialValue = useRef(initialValue)
@@ -107,7 +77,7 @@ export default function useStorageHandler<T>(
   latestInitialValue.current = initialValue
 
   useEffect(() => {
-    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue, pendingOwnWrites)
+    const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue)
 
     storage.onChanged.addListener(handleStorage)
 
@@ -116,5 +86,5 @@ export default function useStorageHandler<T>(
         storage.onChanged.removeListener(handleStorage)
       }
     }
-  }, [key, storage.onChanged, storageKey, applyValue, pendingOwnWrites])
+  }, [key, storage.onChanged, storageKey, applyValue])
 }


### PR DESCRIPTION
## Summary

- remove the own-write history and filtering mechanism
- apply every matching storage change reported by the backend, including changes caused by the writer
- update coverage and documentation for stored non-finite numbers becoming null

## Verification

- RED on the previous implementation: 5 intended failures for sync and async own events plus NaN and both infinities
- targeted tests: 76 passed
- full test suite: 149 passed
- randomized full suite: 149 passed
- typecheck, lint, build, and diff check passed
- independent correctness, test-sensitivity, complexity, and design reviews are clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Persisted state now reflects the value returned from storage after a write, ensuring in-memory data matches its persisted representation.
  * Storage updates from a component’s own writes are applied consistently, including later matching updates.
  * Persisting `NaN`, `Infinity`, or `-Infinity` now results in `null` in the in-memory state, matching JSON storage behavior.

* **Documentation**
  * Updated documentation to describe the handling of persisted special numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->