### PR TITLE
ci: remove manual release increments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,22 +22,9 @@ on:
   push:
     branches:
       - main
-  # Kept beside the automatic trigger for what a push cannot express: forcing an increment the
-  # history understates, and rehearsing the pipeline with --dry-run. It is also the only way to
-  # retry a release whose commits already sit on main, after an outage at npm or GitHub, without
-  # inventing an empty commit to push.
+  # Allows dry runs and retrying a release after an npm or GitHub outage.
   workflow_dispatch:
     inputs:
-      increment:
-        description: 'Version increment. Leave as "auto" to derive it from conventional commits.'
-        required: false
-        type: choice
-        options:
-          - auto
-          - patch
-          - minor
-          - major
-        default: auto
       # A run that died after the tag was pushed cannot be finished by starting an ordinary one:
       # the tag is the newest, no commits follow it, and the release ends in "No new version to
       # release" having done nothing. This targets the version already tagged instead of deriving
@@ -108,20 +95,14 @@ jobs:
         # token path whenever it is set, instead of using OIDC.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INCREMENT: ${{ inputs.increment }}
           RETRY_CURRENT: ${{ inputs.retry-current }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           args=()
 
-          # Retrying targets the version already tagged, so an increment would contradict it.
-          # The inputs are all empty on any event other than workflow_dispatch, and testing
-          # against 'auto' alone would hand release-it an empty positional argument, which is
-          # why the emptiness is checked first.
+          # Retrying targets the version already tagged rather than deriving a new one.
           if [ "$RETRY_CURRENT" = 'true' ]; then
             args+=('--no-increment')
-          elif [ -n "$INCREMENT" ] && [ "$INCREMENT" != 'auto' ]; then
-            args+=("$INCREMENT")
           fi
 
           if [ "$DRY_RUN" = 'true' ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,8 @@ heading containing `null`, as in `## [null](compare/v1.0.0...vnull)`. That is th
 formatting a heading before the run decides there is no version; nothing is written and nothing is
 published. It is noise in the log, not a symptom.
 
-The workflow can also be started by hand from the Actions tab, which is how you force an increment
-the commit history understates, rehearse the whole thing with `--dry-run`, or retry a release whose
-commits are already on `main` after an outage.
+The workflow can also be started by hand from the Actions tab to rehearse the release with
+`--dry-run` or retry the currently tagged release after an outage.
 
 ## Reporting bugs and security issues
 


### PR DESCRIPTION
## Summary

- remove the manual patch, minor, and major increment selector
- keep automatic commit-derived releases on every push to main
- keep manual dry runs and retrying the currently tagged release
- update contributor guidance to match the workflow

## Verification

- actionlint, Bash syntax, and ShellCheck passed
- argument matrix verified push, default dispatch, retry, dry run, and retry plus dry run
- the same matrix proved patch, minor, and major overrides are no longer accepted
- independent correctness, test-sensitivity, complexity, and design reviews are clear