### PR TITLE
fix: use each async key's initial value

### DIFF
--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -1,7 +1,7 @@
 import { createAsyncPersistedState } from '../src'
 import { local as storage } from '../src/storages/browser-storage'
-import { waitFor } from '@testing-library/react'
-import { renderHook, cleanup, act } from '@testing-library/react'
+import React, { Suspense, startTransition } from 'react'
+import { renderHook, cleanup, act, render, screen, waitFor } from '@testing-library/react'
 import type { AsyncStorage, StorageChange, StorageChangeListener } from '../src/@types/storage'
 
 const [usePersistedState, clear] = createAsyncPersistedState('test', storage)
@@ -211,6 +211,66 @@ describe('mount order', () => {
 })
 
 describe('changing key', () => {
+  test('keeps the committed key initial value while a new key render is suspended', async () => {
+    const { asyncStorage, releaseReads } = createFakeAsyncStorage(
+      { 'persisted_state_hook:suspendedKey': JSON.stringify({ unrelated: 'persisted' }) },
+      1,
+    )
+    const [useKeyedPersistedState] = createAsyncPersistedState('suspendedKey', asyncStorage)
+    let isSecondRenderPending = true
+    let releaseSecondRender: DeferredResolve = () => undefined
+    const secondRenderPending = new Promise<void>(resolve => {
+      releaseSecondRender = () => {
+        isSecondRenderPending = false
+        resolve()
+      }
+    })
+    const KeyedState = ({ itemKey, initialValue }: { itemKey: string; initialValue: string }) => {
+      const [value] = useKeyedPersistedState(itemKey, initialValue)
+
+      if (itemKey === 'second' && isSecondRenderPending) throw secondRenderPending
+
+      return <div role="status">{`${itemKey}:${value}`}</div>
+    }
+    const { rerender } = render(
+      <Suspense fallback="loading">
+        <KeyedState itemKey="first" initialValue="initial-first" />
+      </Suspense>,
+    )
+
+    expect(screen.getByRole('status').textContent).toBe('first:initial-first')
+
+    act(() => {
+      startTransition(() => {
+        rerender(
+          <Suspense fallback="loading">
+            <KeyedState itemKey="second" initialValue="initial-second" />
+          </Suspense>,
+        )
+      })
+    })
+
+    expect(screen.getByRole('status').textContent).toBe('first:initial-first')
+
+    try {
+      await act(async () => {
+        releaseReads()
+      })
+
+      expect(screen.getByRole('status').textContent).toBe('first:initial-first')
+
+      await act(async () => {
+        await asyncStorage.remove('persisted_state_hook:suspendedKey')
+      })
+
+      expect(screen.getByRole('status').textContent).toBe('first:initial-first')
+    } finally {
+      await act(async () => {
+        releaseSecondRender()
+      })
+    }
+  })
+
   test('ignores a load left in flight by the previous key', async () => {
     const { asyncStorage, releaseReads } = createFakeAsyncStorage(
       { 'persisted_state_hook:keys': JSON.stringify({ first: 'value-first', second: 'value-second' }) },
@@ -256,6 +316,25 @@ describe('changing key', () => {
     await act(async () => {})
 
     expect(result.current[0]).toBe('value-second')
+  })
+
+  test('uses the new key initial value when no value is persisted', async () => {
+    const { asyncStorage } = createFakeAsyncStorage({
+      'persisted_state_hook:keyInitialValues': JSON.stringify({ first: 'persisted-first' }),
+    })
+    const [useKeyedPersistedState] = createAsyncPersistedState('keyInitialValues', asyncStorage)
+    const { result, rerender } = renderHook(
+      ({ itemKey, initialValue }) => useKeyedPersistedState(itemKey, initialValue),
+      {
+        initialProps: { itemKey: 'first', initialValue: 'initial-first' },
+      },
+    )
+
+    await waitFor(() => expect(result.current[0]).toBe('persisted-first'))
+
+    rerender({ itemKey: 'second', initialValue: 'initial-second' })
+
+    await waitFor(() => expect(result.current[0]).toBe('initial-second'))
   })
 })
 

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -320,13 +320,13 @@ describe('storage access', () => {
     const [useSpiedPersistedState] = createPersistedState('reads', spyStorage)
     const { rerender } = renderHook(() => useSpiedPersistedState('foo', 'bar'))
 
-    const readsAfterMount = get.mock.calls.length
+    expect(get).toHaveBeenCalledTimes(1)
 
     rerender()
     rerender()
     rerender()
 
-    expect(get.mock.calls.length).toBe(readsAfterMount)
+    expect(get).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -75,8 +75,12 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
       [key, applyValue],
     )
 
-    // The first render's initial value: reloading on a later identity would re-run the effect forever.
-    const mountInitialValue = useRef(initialValue)
+    // State binds the fallback to a committed key; same-key rerenders retain useState semantics.
+    const [keyInitialValue, setKeyInitialValue] = useState({ key, value: initialValue })
+
+    if (keyInitialValue.key !== key) {
+      setKeyInitialValue({ key, value: initialValue })
+    }
 
     // Subscribed before the load: effects run in declaration order, and reading first would lose writes in between.
     useStorageHandler<T>(key, safeStorageKey, applyValue, storage, initialValue)
@@ -93,7 +97,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
 
           if (isCancelled || hasAppliedValue.current) return
 
-          applyValue(getPersistedValue<T>(key, mountInitialValue.current, persist[safeStorageKey]))
+          applyValue(getPersistedValue<T>(key, keyInitialValue.value, persist[safeStorageKey]))
         } catch (err) {
           // Nothing awaits this load, so an unclaimed rejection would surface as an uncaught error.
           console.error("use-persisted-state: Can't read value from storage", err)
@@ -105,7 +109,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
       return () => {
         isCancelled = true
       }
-    }, [key, applyValue])
+    }, [key, keyInitialValue, applyValue])
 
     return [state, setPersistedState]
   }

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -1,7 +1,9 @@
 import type React from 'react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import type { AsyncStorage, Storage, StorageChange } from '../@types/storage'
 import { isFunction, isObject } from '@plq/is'
+
+const useIsomorphicLayoutEffect = typeof globalThis.window === 'undefined' ? useEffect : useLayoutEffect
 
 // A stored `null` is a value, so absence needs a status of its own rather than a `null` value.
 type StoredValue<T> = { status: 'stored'; value: T } | { status: 'unavailable' }
@@ -71,10 +73,12 @@ export default function useStorageHandler<T>(
   storage: AsyncStorage | Storage,
   initialValue: T | (() => T),
 ): void {
-  // A ref, not a dependency: an inline initial value changes identity every render and would churn it.
   const latestInitialValue = useRef(initialValue)
 
-  latestInitialValue.current = initialValue
+  // An abandoned render must not change the fallback observed by the active listener.
+  useIsomorphicLayoutEffect(() => {
+    latestInitialValue.current = initialValue
+  }, [initialValue])
 
   useEffect(() => {
     const handleStorage = createStorageHandler<T>(key, storageKey, applyValue, latestInitialValue)


### PR DESCRIPTION
## Summary

- use the new key's initial value when an async storage entry is absent
- prevent abandoned renders from changing the fallback observed by the committed storage listener
- strengthen lifecycle tests with exact read counts and concurrent React coverage

## Verification

- `npm test -- --runInBand` — 151 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run check:package` — 54 smoke checks and all package checks passed
- independent correctness, design, complexity, and mutation-sensitivity reviews passed

The regression tests were independently verified to fail when restoring the frozen mount fallback, render-time ref mutations, or the missing initial storage read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed persisted state when switching between storage keys, ensuring each key uses its own saved value or supplied initial value.
  - Improved behavior during suspended or interrupted renders so the active key and value remain consistent.
  - Prevented fallback values from changing unexpectedly during abandoned renders.
  - Improved storage synchronization and loading behavior when persisted state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->