### PR TITLE
fix: surface storage write failures to the caller

### DIFF
--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -42,6 +42,8 @@ declarations, `publint` and `attw`; see [packaging](../../docs/packaging.md).
 
 Public API changes follow semver. A behaviour change that users can observe — what the hook returns,
 when it re-renders, what lands in storage — is breaking even when the type signature is untouched.
+Restoring an established contract is the exception: that is a patch fix even though the correction is
+observable. Newly incompatible behaviour remains breaking.
 
 Releases are cut automatically from every push to `main`, so merging a pull request is what publishes.
 The version comes from the commit messages alone: only `feat`, `feature`, `fix`, `perf`, `revert` and

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ persisted_state_hook:example → {"count":0}
 
 Storage backends only ever see serialized strings. Anything you persist ends up unencrypted in the underlying storage — do not store secrets or sensitive data (see [SECURITY.md](https://github.com/Akurganow/use-persisted-state/blob/main/SECURITY.md)).
 
-A change reported without a `newValue` is the backend's removal signal: every hook on that entry
-resets to its latest initial value, whatever `oldValue` holds. On an asynchronous backend a factory
+A change reported with an absent or `null` `newValue` is the backend's removal signal: every hook on
+that entry resets to its latest initial value, whatever `oldValue` holds. On an asynchronous backend a factory
 serializes its own writes and removals, so a failed operation rejects its caller without stopping
 the ones queued behind it. Separate factories and writers outside the library are not coordinated.
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ const [state, setState] = usePersistedState(key, initialValue)
 
 Works like `useState`: returns the current state and a setter that accepts either a value or an updater function (`prev => next`). In addition, every update is written to the storage backend, and external changes to the stored value update the state.
 
-- Values are serialized with `JSON.stringify`, so they must be JSON-serializable (no functions, class instances, `Map`, `Set`, etc.). A few values serialize into something else rather than failing outright — see [Values JSON cannot carry](#values-json-cannot-carry).
+- Values follow `JSON.stringify`: unsupported members may be omitted or transformed, while values that make serialization throw are not persisted. See [Values JSON cannot carry](#values-json-cannot-carry).
+- Setters update React state optimistically before persistence. A synchronous setter throws and an asynchronous setter rejects if reading, parsing, serializing, or writing the shared entry fails. Parsing and serialization failures leave the stored entry unchanged.
+- **Await an asynchronous setter, or give it a `catch`.** It returns a promise, and a rejected one nobody handles ends the process on Node 15 and later.
 - With an asynchronous backend, the hook renders `initialValue` first and updates once the stored value has loaded.
 
 ### `clear()`
 
-Removes the factory's whole storage entry. Hooks created by that factory fall back to their initial values. Returns `void` for synchronous backends and `Promise<void>` for asynchronous ones.
+Removes the factory's whole storage entry. Hooks created by that factory fall back to their initial values. An entry that was not there is not reported as removed, so nothing resets. Returns `void` for synchronous backends and `Promise<void>` for asynchronous ones.
 
 ### TypeScript
 
@@ -225,13 +227,25 @@ persisted_state_hook:example → {"count":0}
 
 Storage backends only ever see serialized strings. Anything you persist ends up unencrypted in the underlying storage — do not store secrets or sensitive data (see [SECURITY.md](https://github.com/Akurganow/use-persisted-state/blob/main/SECURITY.md)).
 
+A change reported without a `newValue` is the backend's removal signal: every hook on that entry
+resets to its latest initial value, whatever `oldValue` holds. On an asynchronous backend a factory
+serializes its own writes and removals, so a failed operation rejects its caller without stopping
+the ones queued behind it. Separate factories and writers outside the library are not coordinated.
+
 ### An entry the library cannot read
 
 A write replaces the factory's whole entry, so there is nothing safe to store when the entry already
-there is a string that will not parse, or parses to something that is not an object — another
-library writing under the same key, or a write cut short. The setter reports the failure on
-`console.error`, keeps the value you set in memory and writes nothing, leaving every other hook's
-key exactly where it is. The factory's `clear` removes the entry and lets writing resume.
+there is a string that will not parse — the empty string included — or parses to something that is
+not an object: another library writing under the same key, or a write cut short. Such an entry is
+never rebuilt, and every other hook's key stays exactly where it is:
+
+- an initial read reports the entry on `console.error` and the hook mounts on its initial value;
+- a storage change carrying such an entry is reported and ignored, leaving the hook where it is;
+- a setter keeps the value you set in memory, writes nothing, and then throws on a synchronous
+  backend or rejects on an asynchronous one, so the failure is yours to handle. Earlier versions
+  reported it on `console.error` instead; nothing is logged for a failed write now.
+
+The factory's `clear` removes the entry and lets writing resume.
 
 This reaches as far as the adapter reports. Web storage holds only strings, so anything under the
 key comes back and is checked. Extension storage holds arbitrary JSON, and the bundled adapters
@@ -245,10 +259,9 @@ A few values do not survive `JSON.stringify`. This follows from the format rathe
 the library makes, and no adapter can repair it: once a value has been written, nothing in storage
 tells a `null` you stored apart from a `null` that JSON produced.
 
-- **`undefined`** — the key is dropped, so nothing reaches storage at all. The component that set it
-  keeps `undefined` in memory, as `useState` would, and other components already mounted on that key
-  see no change and keep the value they hold. After a remount or a reload the key is absent, so the
-  initial value comes back.
+- **`undefined`** — JSON omits that hook key. The writer retains `undefined`, the shared entry is
+  rewritten without that key while sibling keys survive, mounted listeners receiving an entry
+  without the key keep their current value, and a fresh reader uses its initial value.
 - **`NaN`, `Infinity`, `-Infinity`** — these are written as `null`. A storage change reported by the
   backend applies that `null` to every listening component, including the writer. Any reader after
   a reload also reads back `null`.

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -62,11 +62,14 @@ function createFakeAsyncStorage(entries: { [key: string]: string } = {}, deferre
     const changes: { [key: string]: StorageChange } = {}
 
     for (const key of toKeyList(keys)) {
-      changes[key] = { oldValue: stored[key] ?? null, newValue: null }
+      // As the bundled adapters do: a key that held nothing is not reported removed.
+      if (!(key in stored)) continue
+
+      changes[key] = { oldValue: stored[key], newValue: null }
       delete stored[key]
     }
 
-    fire(changes)
+    if (Object.keys(changes).length > 0) fire(changes)
   })
   const asyncStorage: AsyncStorage = {
     get,
@@ -166,17 +169,20 @@ describe('reference initial values', () => {
 })
 
 describe('functional updates', () => {
-  test('applies every functional update queued in one batch', async () => {
-    const { asyncStorage } = createFakeAsyncStorage()
+  test('persists every functional update queued in one batch', async () => {
+    const { asyncStorage, stored } = createFakeAsyncStorage()
     const [useCountPersistedState] = createAsyncPersistedState('updates', asyncStorage)
     const { result } = renderHook(() => useCountPersistedState('count', 0))
 
     await act(async () => {
-      result.current[1](previous => previous + 1)
-      result.current[1](previous => previous + 1)
+      const first = result.current[1](previous => previous + 1)
+      const second = result.current[1](previous => previous + 1)
+
+      await Promise.all([first, second])
     })
 
     expect(result.current[0]).toBe(2)
+    expect(JSON.parse(stored['persisted_state_hook:updates'])).toEqual({ count: 2 })
   })
 })
 
@@ -484,6 +490,32 @@ describe('storage round-trips', () => {
 
     expect(result.current[0]).toEqual(applied)
     expect(result.current[0]).not.toBe(applied)
+  })
+
+  test('rewrites the entry without the key when a setter receives undefined', async () => {
+    const entryKey = 'persisted_state_hook:undefinedAsync'
+    // Seeded with the target key, so a setter that never persists leaves
+    // 'persisted' behind for the fresh reader instead of its initial value.
+    const { asyncStorage, stored } = createFakeAsyncStorage({
+      [entryKey]: JSON.stringify({ target: 'persisted', sibling: 'kept' }),
+    })
+    const [useUndefinedState] = createAsyncPersistedState('undefinedAsync', asyncStorage)
+    const { result } = renderHook(() => useUndefinedState<string | undefined>('target', 'initial'))
+
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current[1](undefined)
+    })
+
+    expect(result.current[0]).toBeUndefined()
+    expect(JSON.parse(stored[entryKey])).toEqual({ sibling: 'kept' })
+
+    const { result: reader } = renderHook(() => useUndefinedState<string | undefined>('target', 'fresh initial'))
+
+    await act(async () => {})
+
+    expect(reader.current[0]).toBe('fresh initial')
   })
 })
 

--- a/__tests__/create-async-persisted-state.test.tsx
+++ b/__tests__/create-async-persisted-state.test.tsx
@@ -48,28 +48,30 @@ function createFakeAsyncStorage(entries: { [key: string]: string } = {}, deferre
 
     return result
   })
+  const set = jest.fn(async (items: { [key: string]: string }) => {
+    const changes: { [key: string]: StorageChange } = {}
+
+    for (const [key, value] of Object.entries(items)) {
+      changes[key] = { oldValue: stored[key] ?? null, newValue: value }
+      stored[key] = value
+    }
+
+    fire(changes)
+  })
+  const remove = jest.fn(async (keys: string | string[]) => {
+    const changes: { [key: string]: StorageChange } = {}
+
+    for (const key of toKeyList(keys)) {
+      changes[key] = { oldValue: stored[key] ?? null, newValue: null }
+      delete stored[key]
+    }
+
+    fire(changes)
+  })
   const asyncStorage: AsyncStorage = {
     get,
-    set: jest.fn(async items => {
-      const changes: { [key: string]: StorageChange } = {}
-
-      for (const [key, value] of Object.entries(items)) {
-        changes[key] = { oldValue: stored[key] ?? null, newValue: value }
-        stored[key] = value
-      }
-
-      fire(changes)
-    }),
-    remove: jest.fn(async keys => {
-      const changes: { [key: string]: StorageChange } = {}
-
-      for (const key of toKeyList(keys)) {
-        changes[key] = { oldValue: stored[key] ?? null, newValue: null }
-        delete stored[key]
-      }
-
-      fire(changes)
-    }),
+    set,
+    remove,
     onChanged: {
       addListener: listener => {
         listeners.add(listener)
@@ -86,7 +88,7 @@ function createFakeAsyncStorage(entries: { [key: string]: string } = {}, deferre
     }
   }
 
-  return { asyncStorage, get, releaseReads, stored }
+  return { asyncStorage, get, set, remove, releaseReads, stored }
 }
 
 describe('hook defined correctly', () => {
@@ -485,103 +487,157 @@ describe('storage round-trips', () => {
   })
 })
 
-describe('an entry the hook cannot read', () => {
-  const entryKey = 'persisted_state_hook:damagedAsync'
-  let consoleError: jest.SpyInstance
+describe('write failures', () => {
+  const entryKey = 'persisted_state_hook:writeFailuresAsync'
 
   beforeEach(() => {
     cleanup()
-    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  afterEach(() => {
-    consoleError.mockRestore()
+  test.each([
+    ['an empty shared entry', '', SyntaxError],
+    ['an unreadable entry', '{"alpha":"one"', SyntaxError],
+    ['a non-object entry', 'null', TypeError],
+  ])('rejects for %s, preserves its bytes, and recovers the queue', async (_name, persistedEntry, ErrorType) => {
+    const { asyncStorage, set, stored } = createFakeAsyncStorage({ [entryKey]: persistedEntry })
+    const [useWriteFailureState] = createAsyncPersistedState('writeFailuresAsync', asyncStorage)
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
+      let rejection: unknown
+
+      await act(async () => {})
+      consoleError.mockClear()
+
+      await act(async () => {
+        try {
+          await result.current[1]('requested')
+        } catch (error) {
+          rejection = error
+        }
+      })
+
+      expect(rejection).toBeInstanceOf(ErrorType)
+      expect(result.current[0]).toBe('requested')
+      expect(stored[entryKey]).toBe(persistedEntry)
+      expect(set).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+
+      stored[entryKey] = '{"alpha":"one"}'
+
+      await act(async () => {
+        await result.current[1]('accepted')
+      })
+
+      expect(stored[entryKey]).toBe('{"alpha":"one","gamma":"accepted"}')
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
-  test('is left in storage rather than replaced by the next write', async () => {
-    // Truncated rather than garbage on purpose: alpha and beta are still legible in the bytes,
-    // and only a write that replaces them makes the loss permanent.
-    const damagedEntry = '{"alpha":"one","beta":"two"'
-    const { asyncStorage, stored } = createFakeAsyncStorage({ [entryKey]: damagedEntry })
-    const [useDamagedState] = createAsyncPersistedState('damagedAsync', asyncStorage)
-    const { result } = renderHook(() => useDamagedState('gamma', 'initial'))
+  test('rejects on serialization failure, preserves the entry, and recovers the queue', async () => {
+    const persistedEntry = '{"alpha":"one"}'
+    const { asyncStorage, set, stored } = createFakeAsyncStorage({ [entryKey]: persistedEntry })
+    const [useWriteFailureState] = createAsyncPersistedState('writeFailuresAsync', asyncStorage)
+    const { result } = renderHook(() => useWriteFailureState<object>('gamma', {}))
+    const circular: { self?: unknown } = {}
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    let rejection: unknown
+
+    try {
+      circular.self = circular
+      await act(async () => {})
+
+      await act(async () => {
+        try {
+          await result.current[1](circular)
+        } catch (error) {
+          rejection = error
+        }
+      })
+
+      expect(rejection).toBeInstanceOf(TypeError)
+      expect(result.current[0]).toBe(circular)
+      expect(stored[entryKey]).toBe(persistedEntry)
+      expect(set).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await result.current[1]({ accepted: true })
+      })
+
+      expect(stored[entryKey]).toBe('{"alpha":"one","gamma":{"accepted":true}}')
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  test('propagates a write-time backend get failure and recovers the queue', async () => {
+    const failure = new Error('get failed')
+    const { asyncStorage, get, set, stored } = createFakeAsyncStorage()
+    const [useWriteFailureState] = createAsyncPersistedState('writeFailuresAsync', asyncStorage)
+    const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
+
+    await act(async () => {})
+    get.mockRejectedValueOnce(failure)
 
     await act(async () => {
-      await result.current[1]('three')
+      await expect(result.current[1]('requested')).rejects.toBe(failure)
     })
 
-    // The write is refused, not the update: the caller keeps what it set, and hears why it did
-    // not persist.
-    expect(result.current[0]).toBe('three')
-    expect(stored[entryKey]).toBe(damagedEntry)
-    expect(consoleError).toHaveBeenCalledWith("use-persisted-state: Can't write value to storage", expect.any(Error))
-  })
-
-  test('does not reject the setter, and lets the writes that follow land', async () => {
-    const { asyncStorage, stored } = createFakeAsyncStorage({ [entryKey]: '{"alpha":"one"' })
-    const [useDamagedState] = createAsyncPersistedState('damagedAsync', asyncStorage)
-    const { result } = renderHook(() => useDamagedState('gamma', 'initial'))
-
-    // A refusal that reached the caller as a rejection would be an unhandled rejection in every
-    // consumer that treats the setter as `useState`'s, and those end the process on Node 15+.
-    await act(async () => {
-      await result.current[1]('refused')
-    })
-
-    stored[entryKey] = JSON.stringify({ alpha: 'one' })
+    expect(result.current[0]).toBe('requested')
+    expect(set).not.toHaveBeenCalled()
 
     await act(async () => {
       await result.current[1]('accepted')
     })
 
-    expect(JSON.parse(stored[entryKey])).toEqual({ alpha: 'one', gamma: 'accepted' })
+    expect(stored[entryKey]).toBe('{"gamma":"accepted"}')
   })
-})
 
-describe('a backend that rejects a write', () => {
-  const entryKey = 'persisted_state_hook:flaky'
+  test('propagates a backend set failure and recovers the queue', async () => {
+    const failure = new Error('set failed')
+    const { asyncStorage, set, stored } = createFakeAsyncStorage()
+    const [useWriteFailureState] = createAsyncPersistedState('writeFailuresAsync', asyncStorage)
+    const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
 
-  test('keeps the entry writable for the calls behind the one that failed', async () => {
-    const stored: { [key: string]: string } = {}
-    let shouldRejectWrite = true
-
-    const flakyStorage: AsyncStorage = {
-      get: async keys => {
-        const key = Array.isArray(keys) ? keys[0] : keys
-
-        return key in stored ? { [key]: stored[key] } : {}
-      },
-      set: async items => {
-        if (shouldRejectWrite) {
-          shouldRejectWrite = false
-
-          throw new Error('write rejected')
-        }
-
-        Object.assign(stored, items)
-      },
-      remove: async () => undefined,
-      onChanged: {
-        addListener: () => undefined,
-        removeListener: () => undefined,
-        hasListener: () => false,
-      },
-    }
-    const [useFlakyState] = createAsyncPersistedState('flaky', flakyStorage)
-    const { result } = renderHook(() => useFlakyState<string>('value', 'initial'))
+    await act(async () => {})
+    set.mockRejectedValueOnce(failure)
 
     await act(async () => {
-      await expect(result.current[1]('first')).rejects.toThrow('write rejected')
+      await expect(result.current[1]('requested')).rejects.toBe(failure)
     })
+
+    expect(result.current[0]).toBe('requested')
+    expect(stored[entryKey]).toBeUndefined()
 
     await act(async () => {
-      await result.current[1]('second')
+      await result.current[1]('accepted')
     })
 
-    // Writes on one entry run one at a time, and the next one has to start from the settled
-    // promise rather than from the rejected one: chained onto the rejection it would stay pending
-    // for ever, so one failed write would silently stop every later write on the factory.
-    expect(JSON.parse(stored[entryKey])).toEqual({ value: 'second' })
+    expect(stored[entryKey]).toBe('{"gamma":"accepted"}')
+  })
+
+  test('propagates a backend remove failure and recovers the queue', async () => {
+    const failure = new Error('remove failed')
+    const persistedEntry = '{"gamma":"kept"}'
+    const { asyncStorage, remove, stored } = createFakeAsyncStorage({ [entryKey]: persistedEntry })
+    const [, clearFailedEntry] = createAsyncPersistedState('writeFailuresAsync', asyncStorage)
+
+    remove.mockRejectedValueOnce(failure)
+
+    await act(async () => {
+      await expect(clearFailedEntry()).rejects.toBe(failure)
+    })
+
+    expect(stored[entryKey]).toBe(persistedEntry)
+
+    await act(async () => {
+      await clearFailedEntry()
+    })
+
+    expect(stored[entryKey]).toBeUndefined()
   })
 })
 

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -4,6 +4,37 @@ import createStorage from '../src/utils/create-web-storage'
 import { renderHook, cleanup, act } from '@testing-library/react'
 import type { Storage as StorageAdapter } from '../src/@types/storage'
 
+function createFakeSyncStorage(entries: { [key: string]: string } = {}) {
+  const stored: { [key: string]: string } = { ...entries }
+  const get = jest.fn((keys: string | string[]) => {
+    const result: { [key: string]: string } = {}
+
+    for (const key of Array.isArray(keys) ? keys : [keys]) {
+      if (key in stored) result[key] = stored[key]
+    }
+
+    return result
+  })
+  const set = jest.fn((items: { [key: string]: string }) => {
+    Object.assign(stored, items)
+  })
+  const remove = jest.fn((keys: string | string[]) => {
+    for (const key of Array.isArray(keys) ? keys : [keys]) delete stored[key]
+  })
+  const fakeStorage: StorageAdapter = {
+    get,
+    set,
+    remove,
+    onChanged: {
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      hasListener: () => false,
+    },
+  }
+
+  return { fakeStorage, get, set, remove, stored }
+}
+
 describe('hook defined correctly', () => {
   const [usePersistedState, clear] = createPersistedState('test', storage)
 
@@ -409,62 +440,139 @@ describe('concurrent writers on one factory', () => {
   })
 })
 
-describe('an entry the hook cannot read', () => {
-  const entryKey = 'persisted_state_hook:damaged'
-  const [usePersistedState] = createPersistedState('damaged', storage)
-  let consoleError: jest.SpyInstance
+describe('write failures', () => {
+  const entryKey = 'persisted_state_hook:writeFailures'
 
   beforeEach(() => {
     cleanup()
-    localStorage.clear()
-    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
-  afterEach(() => {
-    consoleError.mockRestore()
+  test.each([
+    ['an empty shared entry', '', SyntaxError],
+    ['an unreadable entry', '{"alpha":"one"', SyntaxError],
+    ['a non-object entry', 'null', TypeError],
+  ])('throws for %s without replacing its bytes', (_name, persistedEntry, ErrorType) => {
+    const { fakeStorage, set, stored } = createFakeSyncStorage({ [entryKey]: persistedEntry })
+    const [useWriteFailureState] = createPersistedState('writeFailures', fakeStorage)
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
+      let thrownBySetter: unknown
+
+      consoleError.mockClear()
+
+      act(() => {
+        try {
+          result.current[1]('requested')
+        } catch (error) {
+          thrownBySetter = error
+        }
+      })
+
+      expect(thrownBySetter).toBeInstanceOf(ErrorType)
+      expect(result.current[0]).toBe('requested')
+      expect(stored[entryKey]).toBe(persistedEntry)
+      expect(set).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
-  test('is left in storage rather than replaced by the next write', () => {
-    // Truncated rather than garbage on purpose: alpha and beta are still legible in the bytes,
-    // and only a write that replaces them makes the loss permanent.
-    const damagedEntry = '{"alpha":"one","beta":"two"'
+  test('throws on serialization failure without replacing the entry', () => {
+    const persistedEntry = '{"alpha":"one"}'
+    const { fakeStorage, set, stored } = createFakeSyncStorage({ [entryKey]: persistedEntry })
+    const [useWriteFailureState] = createPersistedState('writeFailures', fakeStorage)
+    const { result } = renderHook(() => useWriteFailureState<object>('gamma', {}))
+    const circular: { self?: unknown } = {}
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    let thrownBySetter: unknown
 
-    localStorage.setItem(entryKey, damagedEntry)
+    try {
+      circular.self = circular
 
-    const { result } = renderHook(() => usePersistedState('gamma', 'initial'))
+      act(() => {
+        try {
+          result.current[1](circular)
+        } catch (error) {
+          thrownBySetter = error
+        }
+      })
 
-    act(() => {
-      result.current[1]('three')
+      expect(thrownBySetter).toBeInstanceOf(TypeError)
+      expect(result.current[0]).toBe(circular)
+      expect(stored[entryKey]).toBe(persistedEntry)
+      expect(set).not.toHaveBeenCalled()
+      expect(consoleError).not.toHaveBeenCalled()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  test('propagates a write-time backend get failure unchanged', () => {
+    const failure = new Error('get failed')
+    const { fakeStorage, get, set } = createFakeSyncStorage()
+    const [useWriteFailureState] = createPersistedState('writeFailures', fakeStorage)
+    const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
+    let thrownBySetter: unknown
+
+    get.mockImplementationOnce(() => {
+      throw failure
     })
-
-    // The write is refused, not the update: the caller keeps what it set, and hears why it did
-    // not persist.
-    expect(result.current[0]).toBe('three')
-    expect(localStorage.__STORE__[entryKey]).toBe(damagedEntry)
-    expect(consoleError).toHaveBeenCalledWith("use-persisted-state: Can't write value to storage", expect.any(Error))
-  })
-
-  test('survives a write when it is a foreign JSON value', () => {
-    // A bare `null` did not merely lose the write, it threw out of the setter and into whatever
-    // called it, which for a consumer is a click handler. Catching that throw here is the whole
-    // point of the case: a crashing setter leaves the entry untouched for the same reason a
-    // refusal does, so the storage assertion below holds either way and proves nothing on its
-    // own. What separates the two is whether the caller was handed an exception.
-    localStorage.setItem(entryKey, 'null')
-
-    const { result } = renderHook(() => usePersistedState('gamma', 'initial'))
-    let thrownBySetter: unknown = null
 
     act(() => {
       try {
-        result.current[1]('three')
-      } catch (err) {
-        thrownBySetter = err
+        result.current[1]('requested')
+      } catch (error) {
+        thrownBySetter = error
       }
     })
 
-    expect(thrownBySetter).toBeNull()
-    expect(result.current[0]).toBe('three')
-    expect(localStorage.__STORE__[entryKey]).toBe('null')
+    expect(thrownBySetter).toBe(failure)
+    expect(result.current[0]).toBe('requested')
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  test('propagates a backend set failure unchanged', () => {
+    const failure = new Error('set failed')
+    const { fakeStorage, set } = createFakeSyncStorage()
+    const [useWriteFailureState] = createPersistedState('writeFailures', fakeStorage)
+    const { result } = renderHook(() => useWriteFailureState('gamma', 'initial'))
+    let thrownBySetter: unknown
+
+    set.mockImplementationOnce(() => {
+      throw failure
+    })
+
+    act(() => {
+      try {
+        result.current[1]('requested')
+      } catch (error) {
+        thrownBySetter = error
+      }
+    })
+
+    expect(thrownBySetter).toBe(failure)
+    expect(result.current[0]).toBe('requested')
+  })
+
+  test('propagates a backend remove failure unchanged', () => {
+    const failure = new Error('remove failed')
+    const { fakeStorage, remove } = createFakeSyncStorage()
+    const [, clearFailedEntry] = createPersistedState('writeFailures', fakeStorage)
+    let thrownByClear: unknown
+
+    remove.mockImplementationOnce(() => {
+      throw failure
+    })
+
+    try {
+      clearFailedEntry()
+    } catch (error) {
+      thrownByClear = error
+    }
+
+    expect(thrownByClear).toBe(failure)
   })
 })

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -247,15 +247,52 @@ describe('foreign entries under the factory key', () => {
     localStorage.clear()
   })
 
-  test('mounts on its initial value when the entry is a bare JSON primitive', () => {
-    localStorage.setItem(entryKey, '5')
+  test('reports an empty stored entry and falls back to the initial value', () => {
+    localStorage.setItem(entryKey, '')
+    const getItem = localStorage.getItem as jest.Mock
+    const defaultGetItem = getItem.getMockImplementation()
 
-    const { result } = renderHook(() => usePersistedState('foo', 'initial'))
+    // jest-localstorage-mock treats an empty string as absent, unlike Web Storage.
+    getItem.mockImplementation(key => (key in localStorage.__STORE__ ? localStorage.__STORE__[key] : null))
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-    // Another writer on the same backend can leave any JSON under the key. The
-    // read happens in the useState initializer, so a throw here does not degrade
-    // the hook, it stops the component mounting at all.
+    try {
+      const { result } = renderHook(() => usePersistedState('foo', 'initial'))
+
+      expect(result.current[0]).toBe('initial')
+      expect(consoleError).toHaveBeenCalledWith(
+        "use-persisted-state: Can't parse value from storage",
+        expect.any(SyntaxError),
+      )
+    } finally {
+      consoleError.mockRestore()
+      getItem.mockImplementation(defaultGetItem)
+    }
+  })
+
+  test('does not read an inherited constructor as a persisted value', () => {
+    localStorage.setItem(entryKey, '{}')
+
+    const { result } = renderHook(() => usePersistedState('constructor', 'initial'))
+
     expect(result.current[0]).toBe('initial')
+  })
+
+  test('reports a non-object JSON entry and mounts on its initial value', () => {
+    localStorage.setItem(entryKey, '5')
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const { result } = renderHook(() => usePersistedState('foo', 'initial'))
+
+      expect(result.current[0]).toBe('initial')
+      expect(consoleError).toHaveBeenCalledWith(
+        "use-persisted-state: Can't parse value from storage",
+        expect.any(TypeError),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })
 

--- a/__tests__/create-persisted-state.test.tsx
+++ b/__tests__/create-persisted-state.test.tsx
@@ -4,6 +4,7 @@ import createStorage from '../src/utils/create-web-storage'
 import { renderHook, cleanup, act } from '@testing-library/react'
 import type { Storage as StorageAdapter } from '../src/@types/storage'
 
+/** A silent backend: unlike the async fake, it never fires a change event for its own writes. */
 function createFakeSyncStorage(entries: { [key: string]: string } = {}) {
   const stored: { [key: string]: string } = { ...entries }
   const get = jest.fn((keys: string | string[]) => {
@@ -135,7 +136,7 @@ describe('functional updates', () => {
     localStorage.clear()
   })
 
-  test('applies every functional update queued in one batch', () => {
+  test('persists every functional update queued in one batch', () => {
     const { result } = renderHook(() => usePersistedState('count', 0))
 
     act(() => {
@@ -144,6 +145,7 @@ describe('functional updates', () => {
     })
 
     expect(result.current[0]).toBe(2)
+    expect(JSON.parse(localStorage.__STORE__['persisted_state_hook:updates'])).toEqual({ count: 2 })
   })
 })
 
@@ -307,6 +309,26 @@ describe('foreign entries under the factory key', () => {
     const { result } = renderHook(() => usePersistedState('constructor', 'initial'))
 
     expect(result.current[0]).toBe('initial')
+  })
+
+  // `constructor` is an inherited data property; `__proto__` is an accessor on
+  // `Object.prototype`, so it breaks under assignment where `constructor` does not.
+  test('round-trips a __proto__ key without touching the prototype', () => {
+    localStorage.setItem(entryKey, '{"alpha":"kept"}')
+
+    const { result } = renderHook(() => usePersistedState('__proto__', 'initial'))
+
+    expect(result.current[0]).toBe('initial')
+
+    act(() => {
+      result.current[1]('written')
+    })
+
+    expect(localStorage.__STORE__[entryKey]).toBe('{"alpha":"kept","__proto__":"written"}')
+
+    const { result: reader } = renderHook(() => usePersistedState('__proto__', 'fresh initial'))
+
+    expect(reader.current[0]).toBe('written')
   })
 
   test('reports a non-object JSON entry and mounts on its initial value', () => {

--- a/__tests__/data-types.test.tsx
+++ b/__tests__/data-types.test.tsx
@@ -18,16 +18,10 @@ type PersistOutcome<T> = {
 }
 
 /**
- * Writes `value` through the hook and reports the three things persisting it
- * produced: the value the writer holds, the entry that reached storage, and the
- * value a hook that never saw the write reads back.
+ * Persists a value and observes the writer, serialized entry, and a fresh reader.
  *
- * Every case below asserts all three, because each catches a different failure
- * and the held value catches none of them: a hook that writes nothing at all
- * satisfies it, which is what left every `should persist` case here green with
- * the write deleted from the setter. The entry shows what the type encodes to,
- * and the read-back shows a fresh mount decoding it back rather than falling
- * through to its initial value.
+ * Every case asserts all three: the held value alone stays green with the write
+ * deleted from the setter.
  */
 function persistThroughStorage<T>(key: string, initialValue: T, value: T): PersistOutcome<T> {
   const { result: writer } = renderHook(() => usePersistedState<T>(key, initialValue))
@@ -207,9 +201,8 @@ describe('Data Types Persistence', () => {
         result.current[1](undefined)
       })
 
-      // useState parity: JSON cannot persist undefined, but the in-memory
-      // value the setter was given must stay undefined instead of snapping
-      // back to the initial value.
+      // useState parity: JSON cannot persist undefined, but the value the setter
+      // was given must not snap back to the initial value.
       expect(result.current[0]).toBeUndefined()
     })
 
@@ -226,11 +219,31 @@ describe('Data Types Persistence', () => {
         result.current[1](undefined)
       })
 
-      // What the write leaves behind, which is what separates this from the case
-      // above: JSON drops an undefined member, so the entry is written without
-      // the key and a later mount finds nothing to restore.
+      // JSON drops an undefined member, so the entry is written without the key
+      // and a later mount finds nothing to restore.
       expect(localStorage.__STORE__[entryKey]).toBe(JSON.stringify({}))
       expect(result.current[0]).toBeUndefined()
+    })
+
+    test('should drop only the written key from an entry that already held it', () => {
+      // Seeded with the key: writing undefined into an entry that never held it
+      // stays green even when the write keeps the old value instead of dropping it.
+      localStorage.setItem(entryKey, JSON.stringify({ undefinedDropKey: 'persisted', sibling: 'kept' }))
+
+      const { result } = renderHook(() => usePersistedState<string | undefined>('undefinedDropKey', 'initial'))
+
+      act(() => {
+        result.current[1](undefined)
+      })
+
+      expect(result.current[0]).toBeUndefined()
+      expect(readStoredEntry()).toEqual({ sibling: 'kept' })
+
+      const { result: reader } = renderHook(() =>
+        usePersistedState<string | undefined>('undefinedDropKey', 'fresh initial'),
+      )
+
+      expect(reader.current[0]).toBe('fresh initial')
     })
   })
 

--- a/__tests__/get-new-item.test.ts
+++ b/__tests__/get-new-item.test.ts
@@ -8,4 +8,10 @@ describe('get-new-item', () => {
   test('merges a value into an existing entry without losing sibling keys', () => {
     expect(getNewItem('key', '{"alpha":"one","key":"old"}', 'new')).toBe('{"alpha":"one","key":"new"}')
   })
+
+  // A sibling hook's `__proto__` value belongs to whoever stored it and must survive
+  // an unrelated write. Copying the entry by assignment instead of spread drops it.
+  test('keeps a sibling __proto__ key through a merge', () => {
+    expect(getNewItem('alpha', '{"__proto__":"kept","alpha":"one"}', 'two')).toBe('{"__proto__":"kept","alpha":"two"}')
+  })
 })

--- a/__tests__/get-new-item.test.ts
+++ b/__tests__/get-new-item.test.ts
@@ -1,72 +1,11 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import getNewItem from '../src/utils/get-new-item'
 
-describe('get-new-item', function () {
-  beforeAll(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {})
+describe('get-new-item', () => {
+  test('serializes a value into an absent entry', () => {
+    expect(getNewItem('key', undefined, 'value')).toBe('{"key":"value"}')
   })
 
-  afterAll(() => {
-    // @ts-ignore
-    console.error.mockRestore()
-  })
-
-  afterEach(() => {
-    // @ts-ignore
-    console.error.mockClear()
-  })
-
-  it('should return stringified object', function () {
-    expect(getNewItem<string>('key', '{"foo": "bar"}', 'baz')).toEqual(
-      JSON.stringify({
-        foo: 'bar',
-        key: 'baz',
-      }),
-    )
-  })
-
-  it('should report and refuse an entry it cannot parse', function () {
-    // This used to answer with `{"key":"baz"}` and report it. The caller writes what comes back
-    // over the whole entry, so that answer replaced every other hook's key with nothing and took
-    // the bytes a repair still needed with it.
-    expect(() => getNewItem<string>('key', 'foo: bar', 'baz')).toThrow(SyntaxError)
-
-    expect(console.error).toHaveBeenCalled()
-  })
-
-  it('should report and refuse an entry that is not an object of keys', function () {
-    // Any JSON can end up under a factory's key, and merging into a value that is not an object
-    // of keys never produced one: a number or a string came back out of `JSON.stringify` as
-    // itself, an array stayed an array, and `null` threw out of `Object.assign` into the caller.
-    // All four lost the value being set, three of them silently.
-    for (const foreignEntry of ['5', '"text"', '[1,2]', 'null']) {
-      expect(() => getNewItem<string>('key', foreignEntry, 'baz')).toThrow(TypeError)
-    }
-
-    expect(console.error).toHaveBeenCalledTimes(4)
-  })
-
-  it('should not discard the other keys of an entry it cannot parse', function () {
-    // A factory keeps all of its hooks in one storage entry, so what this function returns for a
-    // damaged entry is written over every key in it, not just the one being set. Truncated rather
-    // than garbage on purpose: the other keys are still legible in the bytes, and only a write
-    // that replaces them makes the loss permanent.
-    const damagedEntry = '{"alpha":"one","beta":"two"'
-    let written: string | undefined
-
-    try {
-      written = getNewItem<string>('gamma', damagedEntry, 'three')
-    } catch {
-      // Refusing outright is an acceptable answer to a damaged entry — the bytes stay where a
-      // repair can still reach them, and nothing is written over them.
-      written = undefined
-    }
-
-    // Anything that does come back is going to be written over the whole entry, so it has to
-    // carry the keys that were in it. Naming the one payload this used to return would let an
-    // empty object or an empty string through, and those lose the writing hook's key as well.
-    if (written !== undefined) {
-      expect(JSON.parse(written)).toMatchObject({ alpha: 'one', beta: 'two' })
-    }
+  test('merges a value into an existing entry without losing sibling keys', () => {
+    expect(getNewItem('key', '{"alpha":"one","key":"old"}', 'new')).toBe('{"alpha":"one","key":"new"}')
   })
 })

--- a/__tests__/storages/create-web-storage.test.ts
+++ b/__tests__/storages/create-web-storage.test.ts
@@ -110,6 +110,48 @@ describe('create-web-storage', function () {
     }
   })
 
+  // A storage key is whatever the caller passes. Building the result and the
+  // change map by assignment would send `__proto__` to the accessor on
+  // `Object.prototype`: the write reaches the area but neither the read nor the
+  // listener ever sees it.
+  test('should carry a __proto__ storage key through write, read and notify', function () {
+    const protoStorage = createWebStorage(createMemoryArea({}))
+    const listener = jest.fn()
+
+    // Every `__proto__` below is a computed key on purpose: written as a literal
+    // it would set the prototype instead, and the case would assert nothing.
+    protoStorage.onChanged.addListener(listener)
+
+    try {
+      protoStorage.set({ ['__proto__']: 'written' })
+
+      expect(listener).toHaveBeenCalledWith({ ['__proto__']: { oldValue: null, newValue: 'written' } })
+      expect(protoStorage.get('__proto__')).toEqual({ ['__proto__']: 'written' })
+
+      protoStorage.remove('__proto__')
+
+      expect(listener).toHaveBeenLastCalledWith({ ['__proto__']: { oldValue: 'written', newValue: null } })
+      expect(protoStorage.get('__proto__')).toEqual({})
+    } finally {
+      protoStorage.onChanged.removeListener(listener)
+    }
+  })
+
+  test('should report nothing for a write of no items', function () {
+    const emptyWriteStorage = createWebStorage(createMemoryArea({}))
+    const listener = jest.fn()
+
+    emptyWriteStorage.onChanged.addListener(listener)
+
+    try {
+      emptyWriteStorage.set({})
+
+      expect(listener).not.toHaveBeenCalled()
+    } finally {
+      emptyWriteStorage.onChanged.removeListener(listener)
+    }
+  })
+
   // Without a storage global the adapter is inert, but it still has to satisfy
   // the Storage contract: a caller subscribing on the server must not crash.
   describe('without a storage global', function () {

--- a/__tests__/storages/create-web-storage.test.ts
+++ b/__tests__/storages/create-web-storage.test.ts
@@ -82,6 +82,34 @@ describe('create-web-storage', function () {
     expect(emptyStringStorage.get('emptyKey')).toEqual({ emptyKey: '' })
   })
 
+  // A reported removal resets every hook on the entry to its initial value, and a
+  // functional initial value is called to do it. Reporting one for a key that held
+  // nothing mints a fresh value from an operation that removed nothing.
+  test('should report a removal only for a key that held something', function () {
+    const removalStorage = createWebStorage(createMemoryArea({ present: 'value', emptyKey: '' }))
+    const listener = jest.fn()
+
+    removalStorage.onChanged.addListener(listener)
+
+    try {
+      removalStorage.remove('absent')
+
+      expect(listener).not.toHaveBeenCalled()
+
+      removalStorage.remove('present')
+
+      expect(listener).toHaveBeenCalledWith({ present: { oldValue: 'value', newValue: null } })
+
+      // A stored empty string was removed, so it is reported: absence is `null`
+      // alone, and a truthiness check here would drop this event.
+      removalStorage.remove('emptyKey')
+
+      expect(listener).toHaveBeenLastCalledWith({ emptyKey: { oldValue: '', newValue: null } })
+    } finally {
+      removalStorage.onChanged.removeListener(listener)
+    }
+  })
+
   // Without a storage global the adapter is inert, but it still has to satisfy
   // the Storage contract: a caller subscribing on the server must not crash.
   describe('without a storage global', function () {

--- a/__tests__/utils/extension-storage.test.ts
+++ b/__tests__/utils/extension-storage.test.ts
@@ -53,5 +53,20 @@ describe('extension-storage', function () {
         key: { oldValue: undefined, newValue: 'text' },
       })
     })
+
+    // The backend supplies these keys, so `__proto__` can arrive. Built by
+    // assignment it would reach the accessor on `Object.prototype` and the key
+    // would vanish. Written as computed keys below, or the literals would set a
+    // prototype and assert nothing.
+    test('carries a __proto__ key through both narrowings', function () {
+      expect(toStoredItems({ ['__proto__']: 'kept', other: 'kept too' })).toEqual({
+        ['__proto__']: 'kept',
+        other: 'kept too',
+      })
+
+      expect(toStorageChanges({ ['__proto__']: { oldValue: 'was', newValue: 'is' } })).toEqual({
+        ['__proto__']: { oldValue: 'was', newValue: 'is' },
+      })
+    })
   })
 })

--- a/__tests__/utils/parse-persisted-entry.test.ts
+++ b/__tests__/utils/parse-persisted-entry.test.ts
@@ -1,0 +1,23 @@
+import parsePersistedEntry from '../../src/utils/parse-persisted-entry'
+
+describe('parse-persisted-entry', () => {
+  test('returns an empty entry when storage has no value', () => {
+    expect(parsePersistedEntry(undefined)).toEqual({})
+  })
+
+  test('preserves object values including null', () => {
+    expect(parsePersistedEntry('{"foo":"bar","nullable":null}')).toEqual({ foo: 'bar', nullable: null })
+  })
+
+  test('rejects an empty entry', () => {
+    expect(() => parsePersistedEntry('')).toThrow(SyntaxError)
+  })
+
+  test('rejects malformed JSON', () => {
+    expect(() => parsePersistedEntry('{"foo":')).toThrow(SyntaxError)
+  })
+
+  test.each(['null', '5', '"text"', '[1,2]'])('rejects non-object JSON %s', entry => {
+    expect(() => parsePersistedEntry(entry)).toThrow(TypeError)
+  })
+})

--- a/__tests__/utils/parse-persisted-entry.test.ts
+++ b/__tests__/utils/parse-persisted-entry.test.ts
@@ -1,4 +1,4 @@
-import parsePersistedEntry from '../../src/utils/parse-persisted-entry'
+import parsePersistedEntry, { hasOwnPersistedKey } from '../../src/utils/parse-persisted-entry'
 
 describe('parse-persisted-entry', () => {
   test('returns an empty entry when storage has no value', () => {
@@ -19,5 +19,27 @@ describe('parse-persisted-entry', () => {
 
   test.each(['null', '5', '"text"', '[1,2]'])('rejects non-object JSON %s', entry => {
     expect(() => parsePersistedEntry(entry)).toThrow(TypeError)
+  })
+
+  // A write propagates this one into consumer code, where a bare TypeError names
+  // nothing a reader could trace back to this library.
+  test('names the library in the error a write propagates', () => {
+    expect(() => parsePersistedEntry('5')).toThrow(/^use-persisted-state:/)
+  })
+
+  // A hook key of `__proto__` survives only while the entry is built by JSON.parse,
+  // spread or a computed key. Copying it by assignment hits the accessor on
+  // `Object.prototype` and the key vanishes. `constructor`, an inherited data
+  // property, cannot catch that: assigning over it just creates an own property.
+  test('keeps a __proto__ key as an own property', () => {
+    const entry = parsePersistedEntry('{"__proto__":"stored"}')
+
+    expect(hasOwnPersistedKey(entry, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(entry, '__proto__')?.value).toBe('stored')
+    expect(Object.getPrototypeOf(entry)).toBe(Object.prototype)
+  })
+
+  test('reports an absent __proto__ key rather than the prototype', () => {
+    expect(hasOwnPersistedKey(parsePersistedEntry('{}'), '__proto__')).toBe(false)
   })
 })

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -127,21 +127,20 @@ describe('use-storage-handler', () => {
       expect(applyValue).not.toHaveBeenCalled()
     })
 
-    test('says nothing about an entry that is a bare JSON primitive', () => {
+    test('reports a non-object JSON entry', () => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
 
       renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
 
-      // A number parses, so this is not a broken entry: it is a foreign one, as
-      // routine as an entry carrying only other keys. `in` throws on it, and the
-      // throw runs inside the adapter's notify loop, so it would take out every
-      // listener queued behind this one as well.
       act(() => {
         fire({ [storageKey]: { oldValue: null, newValue: '5' } })
       })
 
-      expect(consoleError).not.toHaveBeenCalled()
+      expect(consoleError).toHaveBeenCalledWith(
+        "use-persisted-state: Can't parse value from storage",
+        expect.any(TypeError),
+      )
       expect(applyValue).not.toHaveBeenCalled()
     })
 
@@ -158,6 +157,23 @@ describe('use-storage-handler', () => {
       expect(consoleError).not.toHaveBeenCalled()
       expect(applyValue).not.toHaveBeenCalled()
     })
+  })
+
+  test('treats only an own constructor property as stored', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+
+    renderHook(() => useStorageHandler('constructor', storageKey, applyValue, storage, 'initial'))
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: null, newValue: '{}' } })
+    })
+    expect(applyValue).not.toHaveBeenCalled()
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: '{}', newValue: JSON.stringify({ constructor: 'stored' }) } })
+    })
+    expect(applyValue).toHaveBeenCalledWith('stored')
   })
 
   test('follows the key the hook is rendering for after it changes', () => {

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -71,19 +71,32 @@ describe('use-storage-handler', () => {
     expect(applyValue).toHaveBeenCalledWith('second')
   })
 
-  test('does not restore a function initialValue the removed entry already held', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
+  describe('removal events', () => {
+    test.each([
+      ['an omitted old value', undefined],
+      ['an equal old value', JSON.stringify({ [itemKey]: 'initial' })],
+      ['unreadable old bytes', 'not json'],
+    ])('restores the initial value for %s', (_name, oldValue) => {
+      const { storage, fire } = createSpyStorage()
+      const applyValue = jest.fn()
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const parse = jest.spyOn(JSON, 'parse')
 
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial'))
+      try {
+        renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial'))
 
-    act(() => {
-      fire({ [storageKey]: { oldValue: JSON.stringify({ [itemKey]: 'initial' }), newValue: null } })
+        act(() => {
+          fire({ [storageKey]: { oldValue, newValue: null } })
+        })
+
+        expect(applyValue).toHaveBeenCalledWith('initial')
+        expect(parse).not.toHaveBeenCalled()
+        expect(consoleError).not.toHaveBeenCalled()
+      } finally {
+        parse.mockRestore()
+        consoleError.mockRestore()
+      }
     })
-
-    // A factory is never equal to the value it produces, so comparing against the
-    // declaration instead of the resolved value re-applies it every time.
-    expect(applyValue).not.toHaveBeenCalled()
   })
 
   test('applies a stored null instead of reading it as no value', () => {
@@ -209,21 +222,6 @@ describe('use-storage-handler', () => {
       fire({
         'persisted_state_hook:elsewhere': { oldValue: null, newValue: JSON.stringify({ [itemKey]: 'not ours' }) },
       })
-    })
-
-    expect(applyValue).not.toHaveBeenCalled()
-  })
-
-  test('does not restore the initial value for a removal that reports nothing removed', () => {
-    const { storage, fire } = createSpyStorage()
-    const applyValue = jest.fn()
-
-    renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, 'initial'))
-
-    // Nothing was there to remove, so nothing changed for this hook. Restoring anyway would
-    // overwrite a value the caller had just set with the initial one.
-    act(() => {
-      fire({ [storageKey]: { oldValue: null, newValue: null } })
     })
 
     expect(applyValue).not.toHaveBeenCalled()

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -50,43 +50,50 @@ describe('use-storage-handler', () => {
     expect(removeListener).not.toHaveBeenCalled()
   })
 
-  test('restores the initialValue of the latest render when the entry is removed', () => {
+  test('evaluates the functional initial value from the latest render only when the entry is removed', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()
+    const firstInitialValue = jest.fn(() => 'first')
+    const latestInitialValue = jest.fn(() => 'second')
 
     const { rerender } = renderHook(
       ({ initialValue }) => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, initialValue),
-      { initialProps: { initialValue: 'first' } },
+      { initialProps: { initialValue: firstInitialValue } },
     )
 
-    rerender({ initialValue: 'second' })
+    rerender({ initialValue: latestInitialValue })
+
+    expect(latestInitialValue).not.toHaveBeenCalled()
+    expect(firstInitialValue).not.toHaveBeenCalled()
 
     act(() => {
       fire({ [storageKey]: { oldValue: JSON.stringify({ [itemKey]: 'stored' }), newValue: null } })
     })
 
-    // The key-change path reads the initialValue of the render it happens on, so
-    // a removal has to read the same one, or one hook answers "what is the
-    // initial value?" two different ways depending on which path asked.
+    expect(firstInitialValue).not.toHaveBeenCalled()
+    expect(latestInitialValue).toHaveBeenCalledTimes(1)
+    expect(applyValue).toHaveBeenCalledTimes(1)
     expect(applyValue).toHaveBeenCalledWith('second')
   })
 
   describe('removal events', () => {
     test.each([
-      ['an omitted old value', undefined],
-      ['an equal old value', JSON.stringify({ [itemKey]: 'initial' })],
-      ['unreadable old bytes', 'not json'],
-    ])('restores the initial value for %s', (_name, oldValue) => {
+      ['an omitted new value', { oldValue: JSON.stringify({ [itemKey]: 'stored' }) }],
+      ['an omitted old value', { newValue: null }],
+      ['an equal old value', { oldValue: JSON.stringify({ [itemKey]: 'initial' }), newValue: null }],
+      ['unreadable old bytes', { oldValue: 'not json', newValue: null }],
+    ] satisfies [string, StorageChange][])('restores the initial value for %s', (_name, change) => {
       const { storage, fire } = createSpyStorage()
       const applyValue = jest.fn()
+
+      renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial'))
+
       const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
       const parse = jest.spyOn(JSON, 'parse')
 
       try {
-        renderHook(() => useStorageHandler<string>(itemKey, storageKey, applyValue, storage, () => 'initial'))
-
         act(() => {
-          fire({ [storageKey]: { oldValue, newValue: null } })
+          fire({ [storageKey]: change })
         })
 
         expect(applyValue).toHaveBeenCalledWith('initial')

--- a/__tests__/utils/use-storage-handler.test.tsx
+++ b/__tests__/utils/use-storage-handler.test.tsx
@@ -196,6 +196,21 @@ describe('use-storage-handler', () => {
     expect(applyValue).toHaveBeenCalledWith('stored')
   })
 
+  // `constructor` is an inherited data property and survives being assigned over,
+  // so only `__proto__` catches an entry copied by assignment on this path. The
+  // loss is silent: an update from another tab never reaches the hook.
+  test('applies an own __proto__ property from a change event', () => {
+    const { storage, fire } = createSpyStorage()
+    const applyValue = jest.fn()
+
+    renderHook(() => useStorageHandler('__proto__', storageKey, applyValue, storage, 'initial'))
+
+    act(() => {
+      fire({ [storageKey]: { oldValue: '{}', newValue: '{"__proto__":"stored"}' } })
+    })
+    expect(applyValue).toHaveBeenCalledWith('stored')
+  })
+
   test('follows the key the hook is rendering for after it changes', () => {
     const { storage, fire } = createSpyStorage()
     const applyValue = jest.fn()

--- a/docs/storage-api.md
+++ b/docs/storage-api.md
@@ -60,10 +60,10 @@ interface StorageChange {
 }
 ```
 
-`changes` maps each changed storage key to its old and new values. When a key is removed, fire the
-listener with a `newValue` of `null` (or omit it) and the previous stored string in `oldValue` —
-the library treats that as a removal and resets affected hooks to their initial values. A removal
-reported without an `oldValue` is ignored.
+`changes` maps each changed storage key to its old and new values. An absent or `null` `newValue` is
+the removal signal: the library resets every affected hook to its latest initial value without
+reading, parsing or comparing `oldValue`. Fire the listener only for operations consumers should
+observe, because a removal always resets, whatever `oldValue` holds.
 
 ## Contract notes
 
@@ -80,9 +80,11 @@ reported without an `oldValue` is ignored.
   hook key. A write replaces all of it, so on an asynchronous storage the library takes one change
   to that key at a time — writes and `clear` alike: your `set` is never called for an entry merged
   from a snapshot another write has since replaced, and a removal is never undone by a write that
-  was already queued behind it. An entry the library cannot read — a string that will not parse, or
-  one that parses to something other than a JSON object — is left untouched instead: the write is
-  reported and skipped.
+  was already queued behind it. That queue belongs to one factory: a failed operation rejects its
+  own caller and the operations queued behind it still run, while separate factories and writers
+  outside the library are not coordinated. An entry the library cannot read — a string that will not
+  parse, or one that parses to something other than a JSON object — is left untouched: `set` is not
+  called at all, and the setter throws on a synchronous backend or rejects on an asynchronous one.
 - **The refusal reaches only as far as `get` reports.** An adapter that narrows a value to absent
   hides it from that check, and the next write replaces it. This is what the bundled extension
   adapters do with the non-string values their backend allows, so a foreign object under a

--- a/src/create-async-persisted-state.ts
+++ b/src/create-async-persisted-state.ts
@@ -30,14 +30,7 @@ export default function createAsyncPersistedState<S extends AsyncStorage>(
   const commitEntry = <T>(key: string, newValue: T): Promise<void> => {
     const write = entryWrites.then(async () => {
       const persistedItem = await storage.get(safeStorageKey)
-      let newItem: string
-
-      try {
-        newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
-      } catch {
-        // A write replaces the whole entry, so an unreadable one is skipped rather than rebuilt without other keys.
-        return
-      }
+      const newItem = getNewItem<T>(key, persistedItem[safeStorageKey], newValue)
 
       await storage.set({ [safeStorageKey]: newItem })
     })

--- a/src/create-persisted-state.ts
+++ b/src/create-persisted-state.ts
@@ -47,14 +47,7 @@ export default function createPersistedState(storageKey: string, storage: Storag
         applyValue(newValue)
 
         const persistedItem = storage.get(safeStorageKey)[safeStorageKey]
-        let newItem: string
-
-        try {
-          newItem = getNewItem<T>(key, persistedItem, newValue)
-        } catch {
-          // A write replaces the whole entry, so an unreadable one is skipped rather than rebuilt without other keys.
-          return
-        }
+        const newItem = getNewItem<T>(key, persistedItem, newValue)
 
         storage.set({ [safeStorageKey]: newItem })
       },

--- a/src/utils/create-web-storage.ts
+++ b/src/utils/create-web-storage.ts
@@ -42,35 +42,36 @@ export default (storage: globalThis.Storage | undefined): Storage => {
 
   return {
     get: keys => {
-      const result: { [key: string]: string } = {}
+      const result = new Map<string, string>()
 
       for (const key of toKeyList(keys)) {
         const item = storage.getItem(key)
 
         // `null` is the only answer meaning absence; an empty string is a value the caller stored.
-        if (item !== null) result[key] = item
+        if (item !== null) result.set(key, item)
       }
 
-      return result
+      return Object.fromEntries(result)
     },
     set: items => {
-      const changes: { [key: string]: StorageChange } = {}
+      const changes = new Map<string, StorageChange>()
 
       for (const [key, value] of Object.entries(items)) {
         const oldValue = storage.getItem(key)
 
         storage.setItem(key, value)
 
-        changes[key] = {
+        changes.set(key, {
           oldValue,
           newValue: value,
-        }
+        })
       }
 
-      if (Object.keys(changes).length > 0) notifier.fire(changes)
+      // Nothing was asked for, so nothing changed.
+      if (changes.size > 0) notifier.fire(Object.fromEntries(changes))
     },
     remove: keys => {
-      const changes: { [key: string]: StorageChange } = {}
+      const changes = new Map<string, StorageChange>()
 
       for (const key of toKeyList(keys)) {
         const oldValue = storage.getItem(key)
@@ -81,13 +82,13 @@ export default (storage: globalThis.Storage | undefined): Storage => {
 
         storage.removeItem(key)
 
-        changes[key] = {
+        changes.set(key, {
           oldValue,
           newValue: null,
-        }
+        })
       }
 
-      if (Object.keys(changes).length > 0) notifier.fire(changes)
+      if (changes.size > 0) notifier.fire(Object.fromEntries(changes))
     },
     onChanged,
   }

--- a/src/utils/create-web-storage.ts
+++ b/src/utils/create-web-storage.ts
@@ -75,6 +75,10 @@ export default (storage: globalThis.Storage | undefined): Storage => {
       for (const key of toKeyList(keys)) {
         const oldValue = storage.getItem(key)
 
+        // Nothing was there, so nothing changed. A reported removal resets every
+        // hook on the entry, calling a functional initial value to do it.
+        if (oldValue === null) continue
+
         storage.removeItem(key)
 
         changes[key] = {

--- a/src/utils/extension-storage.ts
+++ b/src/utils/extension-storage.ts
@@ -20,26 +20,26 @@ export function toStoredValue(value: unknown): string | null | undefined {
 export function toStorageChanges(changes: { [key: string]: { oldValue?: unknown; newValue?: unknown } }): {
   [key: string]: StorageChange
 } {
-  const result: { [key: string]: StorageChange } = {}
+  const result = new Map<string, StorageChange>()
 
   for (const [key, change] of Object.entries(changes)) {
-    result[key] = {
+    result.set(key, {
       oldValue: toStoredValue(change.oldValue),
       newValue: toStoredValue(change.newValue),
-    }
+    })
   }
 
-  return result
+  return Object.fromEntries(result)
 }
 
 export function toStoredItems(items: { [key: string]: unknown }): { [key: string]: string } {
-  const result: { [key: string]: string } = {}
+  const result = new Map<string, string>()
 
   for (const [key, value] of Object.entries(items)) {
-    if (typeof value === 'string') result[key] = value
+    if (typeof value === 'string') result.set(key, value)
   }
 
-  return result
+  return Object.fromEntries(result)
 }
 
 export interface ListenerRegistry {

--- a/src/utils/get-new-item.ts
+++ b/src/utils/get-new-item.ts
@@ -1,8 +1,14 @@
 import parsePersistedEntry from './parse-persisted-entry'
 
-/** Merges `newValue` under `key` into the shared entry, throwing rather than rebuilding one it cannot read. */
+/**
+ * Merges `newValue` under `key` into the shared entry and serializes the result.
+ *
+ * A parse failure propagates: the caller owns an entry this must not rebuild.
+ */
 export default function getNewItem<T>(key: string, persistedItem: string | undefined, newValue: T): string {
   const persist = parsePersistedEntry(persistedItem)
 
+  // Spread and a computed key define own properties; assigning instead would lose
+  // a sibling hook's `__proto__` key. See PersistedEntry.
   return JSON.stringify({ ...persist, [key]: newValue })
 }

--- a/src/utils/get-new-item.ts
+++ b/src/utils/get-new-item.ts
@@ -1,25 +1,8 @@
-import { isObject } from '@plq/is'
+import parsePersistedEntry from './parse-persisted-entry'
 
 /** Merges `newValue` under `key` into the shared entry, throwing rather than rebuilding one it cannot read. */
-export default function getNewItem<T>(key: string, persistedItem: string, newValue: T): string {
-  let persist: unknown
-
-  try {
-    persist = persistedItem ? JSON.parse(persistedItem) : {}
-  } catch (err) {
-    console.error("use-persisted-state: Can't write value to storage", err)
-
-    throw err
-  }
-
-  if (!isObject(persist)) {
-    // Neither a primitive nor an array survives being merged into: the value being set would disappear.
-    const err = new TypeError('the stored entry is not an object of keys')
-
-    console.error("use-persisted-state: Can't write value to storage", err)
-
-    throw err
-  }
+export default function getNewItem<T>(key: string, persistedItem: string | undefined, newValue: T): string {
+  const persist = parsePersistedEntry(persistedItem)
 
   return JSON.stringify({ ...persist, [key]: newValue })
 }

--- a/src/utils/get-persisted-value.ts
+++ b/src/utils/get-persisted-value.ts
@@ -1,11 +1,12 @@
-import { isFunction, isObject } from '@plq/is'
+import { isFunction } from '@plq/is'
+import parsePersistedEntry, { hasOwnPersistedKey, type PersistedEntry } from './parse-persisted-entry'
 
 /** Resolves a hook's starting value by key presence, so a persisted `null` is not mistaken for an absence. */
 export default function getPersistedValue<T>(key: string, initialValue: T | (() => T), persist?: string): T {
-  let initialPersist: unknown
+  let initialPersist: PersistedEntry
 
   try {
-    initialPersist = persist ? JSON.parse(persist) : {}
+    initialPersist = parsePersistedEntry(persist)
   } catch (err) {
     // A shared backend can hold a foreign or truncated entry, so a parse failure must not stop the mount.
     console.error("use-persisted-state: Can't parse value from storage", err)
@@ -15,8 +16,7 @@ export default function getPersistedValue<T>(key: string, initialValue: T | (() 
 
   let initialOrPersistedValue = isFunction(initialValue) ? initialValue() : initialValue
 
-  // `in` throws on a primitive, and this runs in the `useState` initializer, where a throw stops the mount.
-  if (isObject(initialPersist) && key in initialPersist) {
+  if (hasOwnPersistedKey(initialPersist, key)) {
     initialOrPersistedValue = initialPersist[key] as T
   }
 

--- a/src/utils/parse-persisted-entry.ts
+++ b/src/utils/parse-persisted-entry.ts
@@ -1,0 +1,21 @@
+import { isObject } from '@plq/is'
+
+export type PersistedEntry = Record<string, unknown>
+
+export function hasOwnPersistedKey(entry: PersistedEntry, key: string): boolean {
+  // The entry can supply a key named hasOwnProperty, so the prototype method must stay detached.
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: Object.hasOwn is unavailable in part of the supported Node 16 range.
+  return Object.prototype.hasOwnProperty.call(entry, key)
+}
+
+export default function parsePersistedEntry(entry: string | undefined): PersistedEntry {
+  if (entry === undefined) return {}
+
+  const parsed: unknown = JSON.parse(entry)
+
+  if (!isObject(parsed)) {
+    throw new TypeError('the stored entry is not an object of hook keys')
+  }
+
+  return parsed
+}

--- a/src/utils/parse-persisted-entry.ts
+++ b/src/utils/parse-persisted-entry.ts
@@ -1,5 +1,11 @@
 import { isObject } from '@plq/is'
 
+/**
+ * A parsed shared entry. Copy one only by spread or a computed key: `Object.assign`
+ * and plain assignment reach the `__proto__` accessor on `Object.prototype`, which
+ * drops that hook key silently and, for an object value, reparents the entry so
+ * that every later lookup on it inherits keys nobody stored.
+ */
 export type PersistedEntry = Record<string, unknown>
 
 export function hasOwnPersistedKey(entry: PersistedEntry, key: string): boolean {
@@ -14,7 +20,8 @@ export default function parsePersistedEntry(entry: string | undefined): Persiste
   const parsed: unknown = JSON.parse(entry)
 
   if (!isObject(parsed)) {
-    throw new TypeError('the stored entry is not an object of hook keys')
+    // Prefixed because this one reaches consumer code: a write propagates it out of the setter.
+    throw new TypeError('use-persisted-state: the stored entry is not an object of hook keys')
   }
 
   return parsed

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -46,6 +46,8 @@ function createStorageHandler<T>(
       if (key !== storageKey) continue
 
       if (change.newValue === null || change.newValue === undefined) {
+        // Applied every time: the listener cannot prove the current React state
+        // already matches, so comparing `oldValue` would skip resets that are needed.
         applyInitialValue(applyValue, latestInitialValue)
         continue
       }

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -25,21 +25,12 @@ function readStoredValue<T>(key: string, entry: string): StoredValue<T> {
   return { status: 'stored', value: parsed[key] as T }
 }
 
-function applyRemoval<T>(
-  change: StorageChange,
-  itemKey: string,
+function applyInitialValue<T>(
   applyValue: (value: T) => void,
   latestInitialValue: React.RefObject<T | (() => T)>,
 ): void {
-  if (change.oldValue === null || change.oldValue === undefined) return
-
-  const oldValue = readStoredValue<T>(itemKey, change.oldValue)
   const declaredInitialValue = latestInitialValue.current
-  // Resolved before comparing: a factory is never equal to what it produces.
   const initialValue = isFunction(declaredInitialValue) ? declaredInitialValue() : declaredInitialValue
-
-  // Restore redundantly rather than leave stale state when the entry's old value cannot be read.
-  if (oldValue.status === 'stored' && oldValue.value === initialValue) return
 
   applyValue(initialValue)
 }
@@ -55,7 +46,7 @@ function createStorageHandler<T>(
       if (key !== storageKey) continue
 
       if (change.newValue === null || change.newValue === undefined) {
-        applyRemoval<T>(change, itemKey, applyValue, latestInitialValue)
+        applyInitialValue(applyValue, latestInitialValue)
         continue
       }
 

--- a/src/utils/use-storage-handler.ts
+++ b/src/utils/use-storage-handler.ts
@@ -1,7 +1,8 @@
 import type React from 'react'
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import type { AsyncStorage, Storage, StorageChange } from '../@types/storage'
-import { isFunction, isObject } from '@plq/is'
+import { isFunction } from '@plq/is'
+import parsePersistedEntry, { hasOwnPersistedKey, type PersistedEntry } from './parse-persisted-entry'
 
 const useIsomorphicLayoutEffect = typeof globalThis.window === 'undefined' ? useEffect : useLayoutEffect
 
@@ -9,18 +10,17 @@ const useIsomorphicLayoutEffect = typeof globalThis.window === 'undefined' ? use
 type StoredValue<T> = { status: 'stored'; value: T } | { status: 'unavailable' }
 
 function readStoredValue<T>(key: string, entry: string): StoredValue<T> {
-  let parsed: unknown
+  let parsed: PersistedEntry
 
   try {
-    parsed = JSON.parse(entry)
+    parsed = parsePersistedEntry(entry)
   } catch (err) {
     console.error("use-persisted-state: Can't parse value from storage", err)
 
     return { status: 'unavailable' }
   }
 
-  // `in` throws on a primitive, and a throw here cuts off every listener queued behind this one.
-  if (!isObject(parsed) || !(key in parsed)) return { status: 'unavailable' }
+  if (!hasOwnPersistedKey(parsed, key)) return { status: 'unavailable' }
 
   return { status: 'stored', value: parsed[key] as T }
 }


### PR DESCRIPTION
A write onto an entry the library cannot read used to be discarded in silence. v1.4.1 introduced that swallow as a stopgap: before it, an unreadable entry was rebuilt as `{}`, destroying every other hook's key. The stopgap stopped the destruction but traded it for a write the consumer asked for and never got, with nothing but a console line to say so.

Both defects are fixed at the source. A shared entry is parsed in one place, so absence, JSON syntax, top-level shape and own-property lookup answer the same way on every path. An entry that cannot be read is never rebuilt, and the failure reaches the caller instead of a log: the synchronous setter throws, the asynchronous setter rejects, and neither calls `set`, so the original bytes stay where a repair can still reach them.

## What it costs

An asynchronous setter can now reject where it previously resolved. A consumer that treats it as `useState`'s and neither awaits nor catches it sees an unhandled rejection, which ends the process on Node 15 and later. Nothing is logged for a failed write any more — the throw or the rejection is the whole signal. Both are stated in the README, which is where a consumer will look; commit bodies do not reach the changelog, since the preset renders subjects only.

## Scope of the reversal

The swallow shipped in v1.4.1 and lived through four patch releases cut on a single day. A write failure reaching the caller is what v1.4.0 and earlier did, so this restores that contract rather than inventing one. Hence `fix` and a patch release.

## Also fixed

A hook keyed `constructor`, `toString` or any other `Object.prototype` member no longer reads the prototype's value as persisted, and a `__proto__` key now survives a write instead of being swallowed by the accessor it names. An empty stored entry is treated as unreadable rather than absent.

A reported removal now always restores the hook's latest initial value without consulting `oldValue`, and that is only safe because the web storage adapter no longer reports one for a key that held nothing. Left as it was, an unconditional reset would have fired on every `clear()` of an absent entry, resetting hooks that nothing had removed and calling a functional initial value to do it, so `usePersistedState('id', () => randomId())` would mint a fresh id from an operation that changed nothing. A listener cannot tell an observable removal from a no-op; only the adapter can, so the check lives there.

## Adapter maps keyed by the caller

The same accessor bites one level out. The bundled adapters built their result and change maps by assignment, so a storage key of `__proto__` never became an own property: the write reached the area, but `get` read it back as absent and no listener heard it. The adapter disagreed with itself while the stored bytes stayed correct.

These maps are keyed by whatever the caller passes, so they are built as a `Map` and converted once at the boundary — `Object.fromEntries` defines properties rather than assigning them. One rule across `get`, `set` and `remove` in web storage and both narrowings in extension storage, rather than five guards. Unreachable through the hook, whose keys are always `persisted_state_hook:<name>`; it reaches a consumer using an adapter directly.

`set({})` gains the test its guard never had. Not because we settled what an empty `items` means as a contract, but because the guard read as dead code and that is how it would have been deleted.

## Verification

`npm run lint`, `npm run typecheck`, `npm test` (16 suites, 183 tests) in declared and random order, `npm run build`, `npm run check:package` (all four checks), `git diff --check` — all clean on the final tree.

Every new and changed test was proven sensitive by independent mutation, by a different agent than the one that wrote it. Thirty mutations across two rounds; each new test dies alone on the mutation it was written for, with no incidental co-kills masking a weak assertion. One mutation survived the first round — a defensive `Object.assign` copy of a parsed entry, green across the whole suite while silently dropping a `__proto__` hook key — and closing it required tests at all four sites a parsed entry travels.